### PR TITLE
feat(octetcounting): re-use readers

### DIFF
--- a/octetcounting/parser.go
+++ b/octetcounting/parser.go
@@ -5,15 +5,14 @@ import (
 	"io"
 
 	syslog "github.com/leodido/go-syslog/v4"
-	"github.com/leodido/go-syslog/v4/rfc5424"
 	"github.com/leodido/go-syslog/v4/rfc3164"
+	"github.com/leodido/go-syslog/v4/rfc5424"
 )
 
 // parser is capable to parse the input stream containing syslog messages with octetcounting framing.
 //
 // Use NewParser function to instantiate one.
 type parser struct {
-	msglen           int64
 	maxMessageLength int
 	s                Scanner
 	internal         syslog.Machine
@@ -96,6 +95,7 @@ func (p *parser) Parse(r io.Reader) {
 }
 
 func (p *parser) run() {
+	defer p.s.Release()
 	for {
 		var tok Token
 


### PR DESCRIPTION
Solves #16 

This adds a `sync.Pool` that stores `bufio.Reader`s that can be re-used across messages. Previously, we were creating a new bufio.Reader for each new message. This allocates a buffer and results in a `malloc` call for each new message which can be very inefficient in high throughput environments. By introducing a sync.Pool we are able to re-use those allocations across multiple messages, dramatically reducing the cpu hit.