### PR TITLE
feat!: allow passing down machine options from nontransparent/octetcounting parsers

### DIFF
--- a/common/functions.go
+++ b/common/functions.go
@@ -3,7 +3,7 @@ package common
 import "strings"
 
 // UnsafeUTF8DecimalCodePointsToInt converts a slice containing
-// a series of UTF-8 decimal code points into their integer rapresentation.
+// a series of UTF-8 decimal code points into their integer representation.
 //
 // It assumes input code points are in the range 48-57.
 // Returns a pointer since an empty slice is equal to nil and not to the zero value of the codomain (ie., `int`).

--- a/nontransparent/example_test.go
+++ b/nontransparent/example_test.go
@@ -1,13 +1,15 @@
 package nontransparent
 
 import (
-	"github.com/davecgh/go-spew/spew"
 	"io"
 	"math/rand"
 	"strings"
-
-	"github.com/leodido/go-syslog/v4"
 	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/leodido/go-syslog/v4"
+	"github.com/leodido/go-syslog/v4/rfc3164"
+	"github.com/leodido/go-syslog/v4/rfc5424"
 )
 
 func Example_withoutTrailerAtEnd() {
@@ -28,6 +30,50 @@ func Example_withoutTrailerAtEnd() {
 	// }
 }
 
+func Example_withCurrentYear_RFC3164() {
+	results := []syslog.Result{}
+	acc := func(res *syslog.Result) {
+		if res != nil {
+			// Force year to match the one in the comment below
+			x, _ := res.Message.(*rfc3164.SyslogMessage)
+			x.Timestamp = func(t1 *time.Time) *time.Time {
+				currentY := time.Now().Year()
+				t2 := t1.AddDate(2021-currentY, 0, 0)
+
+				return &t2
+			}(x.Timestamp)
+			newRes := syslog.Result{Message: x, Error: res.Error}
+			results = append(results, newRes)
+		}
+	}
+	// Notice the message ends without trailer but we catch it anyway
+	r := strings.NewReader("<13>Dec  2 16:31:03 host app: Test\n")
+	NewParserRFC3164(
+		syslog.WithListener(acc),
+		syslog.WithMachineOptions(rfc3164.WithYear(rfc3164.CurrentYear{})),
+	).Parse(r)
+	output(results)
+	// Output:
+	// ([]syslog.Result) (len=1) {
+	//  (syslog.Result) {
+	//   Message: (*rfc3164.SyslogMessage)({
+	//    Base: (syslog.Base) {
+	//     Facility: (*uint8)(1),
+	//     Severity: (*uint8)(5),
+	//     Priority: (*uint8)(13),
+	//     Timestamp: (*time.Time)(2021-12-02 16:31:03 +0000 UTC),
+	//     Hostname: (*string)((len=4) "host"),
+	//     Appname: (*string)((len=3) "app"),
+	//     ProcID: (*string)(<nil>),
+	//     MsgID: (*string)(<nil>),
+	//     Message: (*string)((len=4) "Test")
+	//    }
+	//   }),
+	//   Error: (error) <nil>
+	//  }
+	// }
+}
+
 func Example_bestEffortWithoutTrailerAtEnd() {
 	results := []syslog.Result{}
 	acc := func(res *syslog.Result) {
@@ -35,7 +81,7 @@ func Example_bestEffortWithoutTrailerAtEnd() {
 	}
 	// Notice the message ends without trailer but we catch it anyway
 	r := strings.NewReader("<1>1 2003-10-11T22:14:15.003Z host.local - - - - mex")
-	NewParser(syslog.WithBestEffort(), syslog.WithListener(acc)).Parse(r)
+	NewParser(syslog.WithMachineOptions(rfc5424.WithBestEffort()), syslog.WithListener(acc)).Parse(r)
 	output(results)
 	// Output:
 	// ([]syslog.Result) (len=1) {
@@ -66,7 +112,7 @@ func Example_bestEffortOnLastOne() {
 		results = append(results, *res)
 	}
 	r := strings.NewReader("<1>1 - - - - - - -\n<3>1\n")
-	NewParser(syslog.WithBestEffort(), syslog.WithListener(acc)).Parse(r)
+	NewParser(syslog.WithMachineOptions(rfc5424.WithBestEffort()), syslog.WithListener(acc)).Parse(r)
 	output(results)
 	// Output:
 	// ([]syslog.Result) (len=2) {
@@ -137,7 +183,7 @@ func Example_intoChannelWithLF() {
 		results <- x
 	}
 
-	p := NewParser(syslog.WithListener(ln), syslog.WithBestEffort())
+	p := NewParser(syslog.WithListener(ln), syslog.WithMachineOptions(rfc5424.WithBestEffort()))
 	go func() {
 		defer close(results)
 		defer r.Close()

--- a/nontransparent/parser.go
+++ b/nontransparent/parser.go
@@ -15,14 +15,14 @@ const nontransparentError int = 0
 const nontransparentEnMain int = 1
 
 type machine struct {
-	trailertyp TrailerType // default is 0 thus TrailerType(LF)
-	trailer    byte
-	candidate  []byte
-	bestEffort bool
-	internal   syslog.Machine
-	emit       syslog.ParserListener
-	readError  error
-	lastChunk  []byte // store last candidate message also if it does not ends with a trailer
+	trailertyp   TrailerType // default is 0 thus TrailerType(LF)
+	trailer      byte
+	candidate    []byte
+	internal     syslog.Machine
+	internalOpts []syslog.MachineOption
+	emit         syslog.ParserListener
+	readError    error
+	lastChunk    []byte // store last candidate message also if it does not ends with a trailer
 }
 
 // Exec implements the ragel.Parser interface.
@@ -183,7 +183,7 @@ func (m *machine) OnCompletion() {
 	// Try to parse last chunk as a candidate
 	if m.readError != nil && len(m.lastChunk) > 0 {
 		res, err := m.internal.Parse(m.lastChunk)
-		if err == nil && !m.bestEffort {
+		if err == nil && !m.internal.HasBestEffort() {
 			res = nil
 			err = m.readError
 		}
@@ -209,11 +209,7 @@ func NewParser(options ...syslog.ParserOption) syslog.Parser {
 	m.trailer = byte(trailer)
 
 	// Create internal parser depending on options
-	if m.bestEffort {
-		m.internal = rfc5424.NewMachine(rfc5424.WithBestEffort())
-	} else {
-		m.internal = rfc5424.NewMachine()
-	}
+	m.internal = rfc5424.NewMachine(m.internalOpts...)
 
 	return m
 }
@@ -232,22 +228,13 @@ func NewParserRFC3164(options ...syslog.ParserOption) syslog.Parser {
 	m.trailer = byte(trailer)
 
 	// Create internal parser depending on options
-	if m.bestEffort {
-		m.internal = rfc3164.NewMachine(rfc3164.WithBestEffort())
-	} else {
-		m.internal = rfc3164.NewMachine()
-	}
+	m.internal = rfc3164.NewMachine(m.internalOpts...)
 
 	return m
 }
 
 // WithMaxMessageLength does nothing for this parser.
 func (m *machine) WithMaxMessageLength(length int) {}
-
-// HasBestEffort tells whether the receiving parser has best effort mode on or off.
-func (m *machine) HasBestEffort() bool {
-	return m.bestEffort
-}
 
 // WithTrailer ... todo(leodido)
 func WithTrailer(t TrailerType) syslog.ParserOption {
@@ -260,11 +247,9 @@ func WithTrailer(t TrailerType) syslog.ParserOption {
 	}
 }
 
-// WithBestEffort implements the syslog.BestEfforter interface.
-//
-// The generic options uses it.
-func (m *machine) WithBestEffort() {
-	m.bestEffort = true
+// WithMachineOptions configures options for the underlying parsing machine.
+func (m *machine) WithMachineOptions(opts ...syslog.MachineOption) {
+	m.internalOpts = append(m.internalOpts, opts...)
 }
 
 // WithListener implements the syslog.Parser interface.

--- a/nontransparent/parser_test.go
+++ b/nontransparent/parser_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 type testCase struct {
-	descr      string
-	input      string
-	substitute bool
-	results    []syslog.Result
-	pResults   []syslog.Result
+	descr         string
+	input         string
+	substitute    bool
+	results       []syslog.Result
+	effortResults []syslog.Result
 }
 
 var testCases []testCase
@@ -28,14 +28,15 @@ func getParsingError(col int) error {
 
 func getTestCases() []testCase {
 	return []testCase{
-		// fixme(leodido)
-		// {
-		// 	"empty",
-		// 	"",
-		// 	[]syslog.Result{},
-		// 	[]syslog.Result{},
-		// },
-
+		// note > no error nor message (nil) returned
+		// TODO: should this return an EOF error or ...?
+		{
+			"empty",
+			"",
+			false,
+			[]syslog.Result{},
+			[]syslog.Result{},
+		},
 		{
 			"1st ok",
 			"<1>1 - - - - - -%[1]s",
@@ -131,8 +132,7 @@ func getTestCases() []testCase {
 				},
 			},
 		},
-
-		// todo(leodido)
+		// TODO: complete the test cases
 		// {
 		// 	"1st ok//incomplete/2nd ok//incomplete",
 		// 	"",
@@ -177,12 +177,12 @@ func TestParse(t *testing.T) {
 			t.Parallel()
 
 			res := []syslog.Result{}
-			effortParser := NewParser(syslog.WithBestEffort(), syslog.WithListener(func(r *syslog.Result) {
+			effortParser := NewParser(syslog.WithMachineOptions(rfc5424.WithBestEffort()), syslog.WithListener(func(r *syslog.Result) {
 				res = append(res, *r)
 			}))
 			effortParser.Parse(strings.NewReader(inputWithLF))
 
-			assert.Equal(t, tc.pResults, res)
+			assert.Equal(t, tc.effortResults, res)
 		})
 
 		// Test with trailer NUL
@@ -206,20 +206,12 @@ func TestParse(t *testing.T) {
 			t.Parallel()
 
 			res := []syslog.Result{}
-			effortParser := NewParser(syslog.WithBestEffort(), syslog.WithListener(func(r *syslog.Result) {
+			effortParser := NewParser(syslog.WithMachineOptions(rfc5424.WithBestEffort()), syslog.WithListener(func(r *syslog.Result) {
 				res = append(res, *r)
 			}), WithTrailer(NUL))
 			effortParser.Parse(strings.NewReader(inputWithNUL))
 
-			assert.Equal(t, tc.pResults, res)
+			assert.Equal(t, tc.effortResults, res)
 		})
 	}
-}
-
-func TestParserBestEffortOption(t *testing.T) {
-	p1 := NewParser().(syslog.BestEfforter)
-	assert.False(t, p1.HasBestEffort())
-
-	p2 := NewParser(syslog.WithBestEffort()).(syslog.BestEfforter)
-	assert.True(t, p2.HasBestEffort())
 }

--- a/octetcounting/example_test.go
+++ b/octetcounting/example_test.go
@@ -261,3 +261,104 @@ func Example_channelOpenBSD() {
 	//  Error: (error) <nil>
 	// }
 }
+
+func Example_channelOpenBSDWithCurrentYear() {
+	messages := []string{
+		"42 <46>Apr 28 11:53:44 syslogd[18823]: start\n",
+		"44 <47>Apr 28 11:53:44 syslogd[18823]: running\n",
+		"88 <86>Apr 28 11:53:46 doas: catap ran command ls / as root from /home/catap/src/go-syslog\n",
+	}
+
+	r, w := io.Pipe()
+
+	go func() {
+		defer w.Close()
+
+		for _, m := range messages {
+			w.Write([]byte(m))
+			time.Sleep(time.Millisecond * 220)
+		}
+	}()
+
+	c := make(chan syslog.Result)
+	emit := func(res *syslog.Result) {
+		c <- *res
+	}
+
+	parser := NewParserRFC3164(
+		syslog.WithMachineOptions(rfc3164.WithBestEffort(), rfc3164.WithYear(rfc3164.CurrentYear{})),
+		syslog.WithListener(emit),
+	)
+	go func() {
+		defer close(c)
+		parser.Parse(r)
+	}()
+
+	for r := range c {
+		mes := r
+		if r.Message != nil {
+			// Force year to match the one in the comment below
+			x := r.Message.(*rfc3164.SyslogMessage)
+			x.Timestamp = func(t1 *time.Time) *time.Time {
+				currentY := time.Now().Year()
+				t2 := t1.AddDate(2024-currentY, 0, 0)
+
+				return &t2
+			}(x.Timestamp)
+			mes = syslog.Result{Message: x, Error: r.Error}
+		}
+		output(mes)
+	}
+
+	r.Close()
+
+	// Output:
+	// (syslog.Result) {
+	//  Message: (*rfc3164.SyslogMessage)({
+	//   Base: (syslog.Base) {
+	//    Facility: (*uint8)(5),
+	//    Severity: (*uint8)(6),
+	//    Priority: (*uint8)(46),
+	//    Timestamp: (*time.Time)(2024-04-28 11:53:44 +0000 UTC),
+	//    Hostname: (*string)(<nil>),
+	//    Appname: (*string)((len=7) "syslogd"),
+	//    ProcID: (*string)((len=5) "18823"),
+	//    MsgID: (*string)(<nil>),
+	//    Message: (*string)((len=5) "start")
+	//   }
+	//  }),
+	//  Error: (error) <nil>
+	// }
+	// (syslog.Result) {
+	//  Message: (*rfc3164.SyslogMessage)({
+	//   Base: (syslog.Base) {
+	//    Facility: (*uint8)(5),
+	//    Severity: (*uint8)(7),
+	//    Priority: (*uint8)(47),
+	//    Timestamp: (*time.Time)(2024-04-28 11:53:44 +0000 UTC),
+	//    Hostname: (*string)(<nil>),
+	//    Appname: (*string)((len=7) "syslogd"),
+	//    ProcID: (*string)((len=5) "18823"),
+	//    MsgID: (*string)(<nil>),
+	//    Message: (*string)((len=7) "running")
+	//   }
+	//  }),
+	//  Error: (error) <nil>
+	// }
+	// (syslog.Result) {
+	//  Message: (*rfc3164.SyslogMessage)({
+	//   Base: (syslog.Base) {
+	//    Facility: (*uint8)(10),
+	//    Severity: (*uint8)(6),
+	//    Priority: (*uint8)(86),
+	//    Timestamp: (*time.Time)(2024-04-28 11:53:46 +0000 UTC),
+	//    Hostname: (*string)(<nil>),
+	//    Appname: (*string)((len=4) "doas"),
+	//    ProcID: (*string)(<nil>),
+	//    MsgID: (*string)(<nil>),
+	//    Message: (*string)((len=61) "catap ran command ls / as root from /home/catap/src/go-syslog")
+	//   }
+	//  }),
+	//  Error: (error) <nil>
+	// }
+}

--- a/octetcounting/example_test.go
+++ b/octetcounting/example_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	syslog "github.com/leodido/go-syslog/v4"
+	"github.com/leodido/go-syslog/v4/rfc3164"
+	"github.com/leodido/go-syslog/v4/rfc5424"
 )
 
 func output(out interface{}) {
@@ -21,7 +23,7 @@ func Example() {
 		results = append(results, *res)
 	}
 	r := strings.NewReader("48 <1>1 2003-10-11T22:14:15.003Z host.local - - - -25 <3>1 - host.local - - - -38 <2>1 - host.local su - - - κόσμε")
-	NewParser(syslog.WithBestEffort(), syslog.WithListener(acc)).Parse(r)
+	NewParser(syslog.WithMachineOptions(rfc5424.WithBestEffort()), syslog.WithListener(acc)).Parse(r)
 	output(results)
 	// Output:
 	// ([]syslog.Result) (len=3) {
@@ -105,7 +107,7 @@ func Example_channel() {
 		c <- *res
 	}
 
-	parser := NewParser(syslog.WithBestEffort(), syslog.WithListener(emit))
+	parser := NewParser(syslog.WithMachineOptions(rfc5424.WithBestEffort()), syslog.WithListener(emit))
 	go func() {
 		defer close(c)
 		parser.Parse(r)
@@ -197,7 +199,7 @@ func Example_channelOpenBSD() {
 		c <- *res
 	}
 
-	parser := NewParserRFC3164(syslog.WithBestEffort(), syslog.WithListener(emit))
+	parser := NewParserRFC3164(syslog.WithMachineOptions(rfc3164.WithBestEffort()), syslog.WithListener(emit))
 	go func() {
 		defer close(c)
 		parser.Parse(r)

--- a/octetcounting/parser_test.go
+++ b/octetcounting/parser_test.go
@@ -626,7 +626,7 @@ func TestParse(t *testing.T) {
 
 			res := []syslog.Result{}
 			effortParser := NewParser(
-				syslog.WithBestEffort(),
+				syslog.WithMachineOptions(rfc5424.WithBestEffort()),
 				syslog.WithListener(func(r *syslog.Result) {
 					res = append(res, *r)
 				}),
@@ -637,12 +637,4 @@ func TestParse(t *testing.T) {
 			assert.Equal(t, tc.bestEffortResults, res)
 		})
 	}
-}
-
-func TestParserBestEffortOption(t *testing.T) {
-	p1 := NewParser().(syslog.BestEfforter)
-	assert.False(t, p1.HasBestEffort())
-
-	p2 := NewParser(syslog.WithBestEffort()).(syslog.BestEfforter)
-	assert.True(t, p2.HasBestEffort())
 }

--- a/octetcounting/performance_test.go
+++ b/octetcounting/performance_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/leodido/go-syslog/v4"
+	"github.com/leodido/go-syslog/v4/rfc5424"
 	syslogtesting "github.com/leodido/go-syslog/v4/testing"
 )
 
@@ -62,7 +63,7 @@ func BenchmarkParse(b *testing.B) {
 		if tc.maxLength == 0 {
 			tc.maxLength = 8192
 		}
-		m := NewParser(syslog.WithBestEffort())
+		m := NewParser(syslog.WithMachineOptions(rfc5424.WithBestEffort()))
 		b.Run(syslogtesting.RightPad(tc.label, 50), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				reader := bytes.NewReader(tc.input)

--- a/options.go
+++ b/options.go
@@ -8,20 +8,19 @@ func WithListener(f ParserListener) ParserOption {
 	}
 }
 
-// WithBestEffort returns a generic options that enables best effort mode for syslog parsers.
-//
-// When passed to a parser it tries to recover as much of the syslog messages as possible.
-func WithBestEffort() ParserOption {
-	return func(p Parser) Parser {
-		p.WithBestEffort()
-		return p
-	}
-}
 
 // WithMaxMessageLength sets the length of the buffer for octect parsing.
 func WithMaxMessageLength(length int) ParserOption {
 	return func(p Parser) Parser {
 		p.WithMaxMessageLength(length)
+		return p
+	}
+}
+
+// WithMachineOptions returns a generic option that sets the machine options for syslog parsers.
+func WithMachineOptions(opts ...MachineOption) ParserOption {
+	return func(p Parser) Parser {
+		p.WithMachineOptions(opts...)
 		return p
 	}
 }

--- a/syslog.go
+++ b/syslog.go
@@ -37,7 +37,6 @@ type Parser interface {
 	Parse(r io.Reader)
 	WithListener(ParserListener)
 	WithMachineOptions(opts ...MachineOption)
-	// BestEfforter
 	MaxMessager
 }
 

--- a/syslog.go
+++ b/syslog.go
@@ -9,8 +9,11 @@ import (
 	"github.com/leodido/go-syslog/v4/common"
 )
 
-// BestEfforter is an interface that wraps the HasBestEffort method.
+// BestEfforter is an interface that wraps the WithBestEffort and the HasBestEffort methods.
 type BestEfforter interface {
+	// WithBestEffort enables best effort mode for syslog parsers.
+	//
+	// When passed to a parser it tries to recover as much of the syslog messages as possible.
 	WithBestEffort()
 	HasBestEffort() bool
 }
@@ -33,7 +36,8 @@ type MachineOption func(m Machine) Machine
 type Parser interface {
 	Parse(r io.Reader)
 	WithListener(ParserListener)
-	BestEfforter
+	WithMachineOptions(opts ...MachineOption)
+	// BestEfforter
 	MaxMessager
 }
 


### PR DESCRIPTION
Fixes #21 

This PR introduces breaking changes because it changes the `Parser` interface.
As a consequence, before merging it I'm waiting for confirmation it works in a real scenario from the `grafana/alloy` folks (see [issue](https://github.com/grafana/alloy/issues/2287)). Also, it would cause **v5** to get released.

## What it does

By merging in this PR,
the `nontransparent` and `octetcounting` parsers can now specify which options to pass down to the underlying syslog RFC machine parsers (RFC3164 vs RFC5424).

It introduces a `syslog.ParserOption` to let you do so: `syslog.WithMachineOptions(opts ...syslog.MachineOption)`.

Example:

```go
nontransparent.NewParserRFC3164(
  syslog.WithMachineOptions(rfc3164.WithYear(rfc3164.CurrentYear{})),
  syslog.WithListener(accumulator),
).Parse(r)
```

