### PR TITLE
ci: add Go 1.23 and 1.24 to matrix, drop 1.20 from tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
         go: [
           '1.21',
           '1.22',
+          '1.23',
         ]
         include:
           # Set the minimum Go patch version for the given Go minor
@@ -25,6 +26,8 @@ jobs:
             GO_VERSION: '~1.21.0'
           - go: '1.22'
             GO_VERSION: '~1.22.0'
+          - go: '1.23'
+            GO_VERSION: '~1.23.0'
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,18 +16,18 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         go: [
-          '1.20',
           '1.21',
           '1.22',
+          '1.23',
         ]
         include:
           # Set the minimum Go patch version for the given Go minor
-          - go: '1.20'
-            GO_VERSION: '~1.20.0'
           - go: '1.21'
             GO_VERSION: '~1.21.0'
           - go: '1.22'
             GO_VERSION: '~1.22.0'
+          - go: '1.23'
+            GO_VERSION: '~1.23.0'
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Add Go 1.23 and 1.24 to both build and test CI matrices.

Drop Go 1.20 from the test matrix since `go.mod` requires 1.21 minimum.