### PR TITLE
build: add Dockerfile with ragel and graphviz

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends ragel graphviz \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add a devcontainer Dockerfile based on `mcr.microsoft.com/devcontainers/base:ubuntu-24.04` with `ragel` and `graphviz` installed.

- **ragel**: needed by `make build` to compile `.go.rl` state machine definitions into Go code
- **graphviz**: needed by `make dots`/`make imgs` for state machine diagram generation