### PR TITLE
build: add devcontainer.json with Go 1.23

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "go-syslog",
+	"build": {
+		"context": ".",
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/go": {
+			"version": "1.23"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Add `devcontainer.json` referencing the Dockerfile and configuring:

- **Go 1.23** via `ghcr.io/devcontainers/features/go` (satisfies `gopls` minimum requirement of 1.23, backward-compatible with the `go 1.21` module directive)
- **golang.go** VS Code extension