### PR TITLE
ci: add Go 1.24 to build and test matrices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
           '1.21',
           '1.22',
           '1.23',
+          '1.24',
         ]
         include:
           # Set the minimum Go patch version for the given Go minor
@@ -28,6 +29,8 @@ jobs:
             GO_VERSION: '~1.22.0'
           - go: '1.23'
             GO_VERSION: '~1.23.0'
+          - go: '1.24'
+            GO_VERSION: '~1.24.0'
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
           '1.21',
           '1.22',
           '1.23',
+          '1.24',
         ]
         include:
           # Set the minimum Go patch version for the given Go minor
@@ -28,6 +29,8 @@ jobs:
             GO_VERSION: '~1.22.0'
           - go: '1.23'
             GO_VERSION: '~1.23.0'
+          - go: '1.24'
+            GO_VERSION: '~1.24.0'
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Add Go 1.24 to both build and test CI matrices, matching the SAST workflow which already tests 1.24.