### PR TITLE
test: increase coverage for common, rfc3164, and rfc5424

### DIFF
--- a/common/functions_test.go
+++ b/common/functions_test.go
@@ -30,3 +30,57 @@ func TestAllDigits(t *testing.T) {
 	res := UnsafeUTF8DecimalCodePointsToInt(slice)
 	assert.Equal(t, 1234567890, res)
 }
+
+func TestRemoveBytes(t *testing.T) {
+	data := []byte(`hello\world`)
+	res := RemoveBytes(data, []int{5}, 0)
+	assert.Equal(t, []byte(`helloworld`), res)
+
+	// Multiple positions
+	data2 := []byte(`a\b\c`)
+	res2 := RemoveBytes(data2, []int{1, 3}, 0)
+	assert.Equal(t, []byte(`abc`), res2)
+
+	// With offset
+	data3 := []byte(`xx\yy`)
+	res3 := RemoveBytes(data3, []int{4}, 2)
+	assert.Equal(t, []byte(`xxyy`), res3)
+
+	// Original data is not modified
+	orig := []byte(`a\b`)
+	RemoveBytes(orig, []int{1}, 0)
+	assert.Equal(t, []byte(`a\b`), orig)
+}
+
+func TestEscapeBytes(t *testing.T) {
+	assert.Equal(t, `\\`, EscapeBytes(`\`))
+	assert.Equal(t, `\]`, EscapeBytes(`]`))
+	assert.Equal(t, `\"`, EscapeBytes(`"`))
+	assert.Equal(t, `hello`, EscapeBytes(`hello`))
+	assert.Equal(t, `a\\b\]c\"d`, EscapeBytes(`a\b]c"d`))
+	assert.Equal(t, ``, EscapeBytes(``))
+}
+
+func TestInBetween(t *testing.T) {
+	assert.True(t, InBetween(5, 1, 10))
+	assert.True(t, InBetween(1, 1, 10))
+	assert.True(t, InBetween(10, 1, 10))
+	assert.False(t, InBetween(0, 1, 10))
+	assert.False(t, InBetween(11, 1, 10))
+}
+
+func TestValidPriority(t *testing.T) {
+	assert.True(t, ValidPriority(0))
+	assert.True(t, ValidPriority(191))
+	assert.True(t, ValidPriority(100))
+	assert.False(t, ValidPriority(192))
+	assert.False(t, ValidPriority(255))
+}
+
+func TestValidVersion(t *testing.T) {
+	assert.True(t, ValidVersion(1))
+	assert.True(t, ValidVersion(999))
+	assert.True(t, ValidVersion(500))
+	assert.False(t, ValidVersion(0))
+	assert.False(t, ValidVersion(1000))
+}

--- a/rfc3164/machine_test.go
+++ b/rfc3164/machine_test.go
@@ -569,3 +569,63 @@ func TestMachineParse(t *testing.T) {
 		})
 	}
 }
+
+func TestMachineHasBestEffort(t *testing.T) {
+	m := NewMachine()
+	assert.False(t, m.HasBestEffort())
+	m.WithBestEffort()
+	assert.True(t, m.HasBestEffort())
+}
+
+func TestMachineErr(t *testing.T) {
+	m := NewMachine().(*machine)
+	// No error before parsing
+	assert.Nil(t, m.Err())
+	// Error after invalid input
+	_, err := m.Parse([]byte("not a syslog message"))
+	assert.Error(t, err)
+	assert.Error(t, m.Err())
+}
+
+func TestParserHasBestEffort(t *testing.T) {
+	p := NewParser()
+	assert.False(t, p.HasBestEffort())
+
+	p2 := NewParser(WithBestEffort())
+	assert.True(t, p2.HasBestEffort())
+}
+
+func TestParserParseInvalid(t *testing.T) {
+	p := NewParser()
+	msg, err := p.Parse([]byte("invalid"))
+	assert.Nil(t, msg)
+	assert.Error(t, err)
+}
+
+func TestParserParseInvalidBestEffort(t *testing.T) {
+	p := NewParser(WithBestEffort())
+	msg, err := p.Parse([]byte(`<13>not valid`))
+	assert.NotNil(t, msg)
+	assert.Error(t, err)
+}
+
+func TestWithMessageCounter(t *testing.T) {
+	m := NewMachine(WithMessageCounter())
+	msg, err := m.Parse([]byte(`<189>643: Jan  8 19:46:03 myhost %LINEPROTO-5-UPDOWN: Line protocol on Interface Loopback100, changed state to up`))
+	assert.NotNil(t, msg)
+	assert.NoError(t, err)
+}
+
+func TestWithSequenceNumber(t *testing.T) {
+	m := NewMachine(WithMessageCounter(), WithSequenceNumber())
+	msg, err := m.Parse([]byte(`<189>105: 000104: Mar 12 07:12:10 myhost %SYS-5-CONFIG_I: Configured from console by console`))
+	assert.NotNil(t, msg)
+	assert.NoError(t, err)
+}
+
+func TestWithCiscoHostname(t *testing.T) {
+	m := NewMachine(WithMessageCounter(), WithCiscoHostname())
+	msg, err := m.Parse([]byte(`<189>269614: hostname1: Apr 11 10:02:08 %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet7/0/34, changed state to up`))
+	assert.NotNil(t, msg)
+	assert.NoError(t, err)
+}

--- a/rfc5424/machine_test.go
+++ b/rfc5424/machine_test.go
@@ -1664,6 +1664,20 @@ func TestMachineBestEffortOption(t *testing.T) {
 	assert.True(t, p2.HasBestEffort())
 }
 
+func TestMachineErr(t *testing.T) {
+	m := NewMachine().(*machine)
+	// No error before parsing
+	assert.Nil(t, m.Err())
+	// Error after invalid input
+	_, err := m.Parse([]byte("not a syslog message"))
+	assert.Error(t, err)
+	assert.Error(t, m.Err())
+	// No error after valid input
+	_, err = m.Parse([]byte(`<1>1 - - - - - -`))
+	assert.NoError(t, err)
+	assert.NoError(t, m.Err())
+}
+
 func TestMachineParse(t *testing.T) {
 	runTestCases(t, append(testCases))
 }


### PR DESCRIPTION
Adds tests to cover all non-generated functions that were at 0% coverage.

### Coverage changes

| Package | Before | After |
|---------|--------|-------|
| `common` | 33.3% | **100%** |
| `rfc3164` | 4.9% | 5.0% |
| `rfc5424` | 58.3% | 58.3% |

The `rfc3164` and `rfc5424` overall numbers barely move because the generated `machine.go` files are 60K+ lines of state transition tables. However, all **non-generated** functions in these packages are now at 100%.

### New tests

- **`common`**: `RemoveBytes`, `EscapeBytes`, `InBetween`, `ValidPriority`, `ValidVersion`
- **`rfc3164`**: `Err`, `HasBestEffort`, parser `HasBestEffort`/`Parse` (valid, invalid, best-effort), `WithMessageCounter`, `WithSequenceNumber`, `WithCiscoHostname`
- **`rfc5424`**: `Err` (nil before parse, error after invalid, nil after valid)