### PR TITLE
test(rfc5424): add `SetMsgID` reproducer for issue #32

### DIFF
--- a/rfc5424/issue32_test.go
+++ b/rfc5424/issue32_test.go
@@ -1,0 +1,99 @@
+package rfc5424
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIssue32_SetMsgID attempts to reproduce https://github.com/leodido/go-syslog/issues/32
+// where SetMsgID() allegedly leaves MsgID as nil.
+func TestIssue32_SetMsgID(t *testing.T) {
+	t.Run("standalone", func(t *testing.T) {
+		m := &SyslogMessage{}
+		m.SetMsgID("myid")
+		assert.NotNil(t, m.MsgID, "MsgID should not be nil after SetMsgID")
+		assert.Equal(t, "myid", *m.MsgID)
+	})
+
+	t.Run("single char", func(t *testing.T) {
+		m := &SyslogMessage{}
+		m.SetMsgID("1")
+		assert.NotNil(t, m.MsgID)
+		assert.Equal(t, "1", *m.MsgID)
+	})
+
+	t.Run("max length 32 chars", func(t *testing.T) {
+		m := &SyslogMessage{}
+		id := "abcdefghijklmnopqrstuvwxyz012345"
+		assert.Len(t, id, 32)
+		m.SetMsgID(id)
+		assert.NotNil(t, m.MsgID)
+		assert.Equal(t, id, *m.MsgID)
+	})
+
+	t.Run("too long is rejected", func(t *testing.T) {
+		m := &SyslogMessage{}
+		id := "abcdefghijklmnopqrstuvwxyz0123456" // 33 chars
+		m.SetMsgID(id)
+		assert.Nil(t, m.MsgID, "MsgID longer than 32 chars should be rejected")
+	})
+
+	t.Run("chained with other setters", func(t *testing.T) {
+		m := &SyslogMessage{}
+		m.SetPriority(165).SetVersion(1).SetMsgID("myid")
+		assert.NotNil(t, m.MsgID, "MsgID should not be nil after chained SetMsgID")
+		assert.Equal(t, "myid", *m.MsgID)
+	})
+
+	t.Run("via Builder interface", func(t *testing.T) {
+		var b Builder = &SyslogMessage{}
+		b.SetPriority(165).SetVersion(1).SetMsgID("myid")
+		sm := b.(*SyslogMessage)
+		assert.NotNil(t, sm.MsgID)
+		assert.Equal(t, "myid", *sm.MsgID)
+	})
+
+	t.Run("serialization round-trip", func(t *testing.T) {
+		m := &SyslogMessage{}
+		m.SetPriority(165)
+		m.SetVersion(1)
+		m.SetTimestamp("2018-10-11T22:14:15.003Z")
+		m.SetHostname("mymach.it")
+		m.SetAppname("myapp")
+		m.SetMsgID("myid")
+		m.SetMessage("test message")
+
+		str, err := m.String()
+		assert.Nil(t, err)
+		assert.Contains(t, str, "myid")
+
+		p := NewParser()
+		parsed, perr := p.Parse([]byte(str))
+		assert.Nil(t, perr)
+		assert.NotNil(t, parsed)
+
+		sm := parsed.(*SyslogMessage)
+		assert.NotNil(t, sm.MsgID, "MsgID should survive serialization round-trip")
+		assert.Equal(t, "myid", *sm.MsgID)
+	})
+
+	t.Run("special characters", func(t *testing.T) {
+		m := &SyslogMessage{}
+		// MSGID allows printable ASCII 33-126 except spaces
+		m.SetMsgID("#1")
+		assert.NotNil(t, m.MsgID)
+		assert.Equal(t, "#1", *m.MsgID)
+
+		m2 := &SyslogMessage{}
+		m2.SetMsgID("msg-id_123")
+		assert.NotNil(t, m2.MsgID)
+		assert.Equal(t, "msg-id_123", *m2.MsgID)
+	})
+
+	t.Run("invalid with space is rejected", func(t *testing.T) {
+		m := &SyslogMessage{}
+		m.SetMsgID("white space not possible")
+		assert.Nil(t, m.MsgID, "MsgID with spaces should be rejected")
+	})
+}


### PR DESCRIPTION
## Description

Adds a reproducer test for #32 (`SetMsgID()` allegedly leaving `MsgID` nil).

After tracing the Ragel FSM in `builder.go`, `SetMsgID` works correctly: the entrypoint `msgid` translates to state 41, which chains through states 486–517 accepting up to 32 printable ASCII characters, and the `_testEof` handler correctly assigns `sm.MsgID`.

The test covers 9 subtests:
- Standalone call
- Single-character and max-length (32) msgids
- Over-length (33 chars) rejection
- Method chaining (`SetPriority().SetVersion().SetMsgID()`)
- Usage through the `Builder` interface
- Full serialization round-trip (build → `String()` → `Parse()`)
- Special characters (`#1`, `msg-id_123`)
- Invalid input (spaces)

All pass on both `HEAD` and `v4.2.0`.

## Related Issue(s)

Ref: #32

## How to test

```bash
go test ./rfc5424/ -run TestIssue32 -v
```