### PR TITLE
feat(rfc3195): BEEP frame scanner and RAW profile parser

### DIFF
--- a/rfc3195/frame.go
+++ b/rfc3195/frame.go
@@ -1,0 +1,225 @@
+package rfc3195
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+// FrameType represents the type of a BEEP frame (RFC 3080 §2.2.1).
+type FrameType int
+
+const (
+	FrameMSG FrameType = iota
+	FrameRPY
+	FrameERR
+	FrameANS
+	FrameNUL
+	FrameSEQ
+)
+
+var frameTypeNames = [...]string{"MSG", "RPY", "ERR", "ANS", "NUL", "SEQ"}
+
+func (ft FrameType) String() string {
+	if int(ft) < len(frameTypeNames) {
+		return frameTypeNames[ft]
+	}
+	return fmt.Sprintf("FrameType(%d)", int(ft))
+}
+
+var keywordToType = map[string]FrameType{
+	"MSG": FrameMSG,
+	"RPY": FrameRPY,
+	"ERR": FrameERR,
+	"ANS": FrameANS,
+	"NUL": FrameNUL,
+	"SEQ": FrameSEQ,
+}
+
+// Frame represents a parsed BEEP frame.
+type Frame struct {
+	Type    FrameType
+	Channel uint32
+	Msgno   uint32
+	More    bool   // '*' = true (intermediate), '.' = false (complete)
+	Seqno   uint32
+	Size    uint32
+	Ansno   uint32 // only meaningful for ANS frames
+	Payload []byte // exactly Size bytes; nil for SEQ frames
+
+	// SEQ frame fields (RFC 3081 §3.1.3)
+	Ackno  uint32 // only meaningful for SEQ frames
+	Window uint32 // only meaningful for SEQ frames
+}
+
+// Scanner reads BEEP frames from an io.Reader.
+type Scanner struct {
+	r *bufio.Reader
+}
+
+// NewScanner creates a Scanner that reads BEEP frames from r.
+func NewScanner(r io.Reader) *Scanner {
+	br, ok := r.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(r)
+	}
+	return &Scanner{r: br}
+}
+
+// Scan reads the next BEEP frame from the underlying reader.
+// Returns io.EOF when no more frames are available.
+func (s *Scanner) Scan() (Frame, error) {
+	line, err := s.r.ReadBytes('\n')
+	if err != nil {
+		if err == io.EOF && len(line) == 0 {
+			return Frame{}, io.EOF
+		}
+		return Frame{}, fmt.Errorf("reading frame header: %w", err)
+	}
+
+	// Strip trailing CRLF
+	if len(line) < 2 || line[len(line)-2] != '\r' || line[len(line)-1] != '\n' {
+		return Frame{}, fmt.Errorf("frame header missing CRLF terminator")
+	}
+	line = line[:len(line)-2]
+
+	fields := bytes.Fields(line)
+	if len(fields) < 1 {
+		return Frame{}, fmt.Errorf("empty frame header")
+	}
+
+	keyword := string(fields[0])
+	ft, ok := keywordToType[keyword]
+	if !ok {
+		return Frame{}, fmt.Errorf("unknown frame keyword: %q", keyword)
+	}
+
+	if ft == FrameSEQ {
+		return s.parseSEQ(fields)
+	}
+
+	return s.parseDataFrame(ft, fields)
+}
+
+// parseSEQ parses a SEQ frame: SEQ channel ackno window CRLF
+// SEQ frames have no payload and no END trailer.
+func (s *Scanner) parseSEQ(fields [][]byte) (Frame, error) {
+	if len(fields) != 4 {
+		return Frame{}, fmt.Errorf("SEQ frame requires 4 fields, got %d", len(fields))
+	}
+
+	channel, err := parseUint32(fields[1], "channel")
+	if err != nil {
+		return Frame{}, err
+	}
+	ackno, err := parseUint32(fields[2], "ackno")
+	if err != nil {
+		return Frame{}, err
+	}
+	window, err := parseUint32(fields[3], "window")
+	if err != nil {
+		return Frame{}, err
+	}
+
+	return Frame{
+		Type:    FrameSEQ,
+		Channel: channel,
+		Ackno:   ackno,
+		Window:  window,
+	}, nil
+}
+
+// parseDataFrame parses MSG, RPY, ERR, ANS, or NUL frames.
+// Format: keyword channel msgno more seqno size [ansno] CRLF payload END CRLF
+func (s *Scanner) parseDataFrame(ft FrameType, fields [][]byte) (Frame, error) {
+	expectedFields := 6
+	if ft == FrameANS {
+		expectedFields = 7
+	}
+	if len(fields) != expectedFields {
+		return Frame{}, fmt.Errorf("%s frame requires %d fields, got %d", ft, expectedFields, len(fields))
+	}
+
+	channel, err := parseUint32(fields[1], "channel")
+	if err != nil {
+		return Frame{}, err
+	}
+	msgno, err := parseUint32(fields[2], "msgno")
+	if err != nil {
+		return Frame{}, err
+	}
+
+	more, err := parseContinuation(fields[3])
+	if err != nil {
+		return Frame{}, err
+	}
+
+	seqno, err := parseUint32(fields[4], "seqno")
+	if err != nil {
+		return Frame{}, err
+	}
+	size, err := parseUint32(fields[5], "size")
+	if err != nil {
+		return Frame{}, err
+	}
+
+	var ansno uint32
+	if ft == FrameANS {
+		ansno, err = parseUint32(fields[6], "ansno")
+		if err != nil {
+			return Frame{}, err
+		}
+	}
+
+	// Read exactly 'size' bytes of payload
+	payload := make([]byte, size)
+	if size > 0 {
+		if _, err := io.ReadFull(s.r, payload); err != nil {
+			return Frame{}, fmt.Errorf("reading payload (%d bytes): %w", size, err)
+		}
+	}
+
+	// Consume END\r\n trailer
+	trailer := make([]byte, 5) // "END\r\n"
+	if _, err := io.ReadFull(s.r, trailer); err != nil {
+		return Frame{}, fmt.Errorf("reading END trailer: %w", err)
+	}
+	if string(trailer) != "END\r\n" {
+		return Frame{}, fmt.Errorf("expected END trailer, got %q", trailer)
+	}
+
+	return Frame{
+		Type:    ft,
+		Channel: channel,
+		Msgno:   msgno,
+		More:    more,
+		Seqno:   seqno,
+		Size:    size,
+		Ansno:   ansno,
+		Payload: payload,
+	}, nil
+}
+
+func parseUint32(b []byte, name string) (uint32, error) {
+	v, err := strconv.ParseUint(string(b), 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", name, b, err)
+	}
+	return uint32(v), nil
+}
+
+func parseContinuation(b []byte) (bool, error) {
+	if len(b) != 1 {
+		return false, fmt.Errorf("invalid continuation indicator %q", b)
+	}
+	switch b[0] {
+	case '*':
+		return true, nil
+	case '.':
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid continuation indicator %q, expected '*' or '.'", b)
+	}
+}

--- a/rfc3195/frame.go
+++ b/rfc3195/frame.go
@@ -39,6 +39,9 @@ var keywordToType = map[string]FrameType{
 }
 
 // Frame represents a parsed BEEP frame.
+//
+// For data frames (MSG, RPY, ERR, ANS, NUL), Payload contains exactly Size
+// bytes. Payload is nil when Size is 0 or for SEQ frames.
 type Frame struct {
 	Type    FrameType
 	Channel uint32
@@ -47,25 +50,59 @@ type Frame struct {
 	Seqno   uint32
 	Size    uint32
 	Ansno   uint32 // only meaningful for ANS frames
-	Payload []byte // exactly Size bytes; nil for SEQ frames
+	Payload []byte
 
 	// SEQ frame fields (RFC 3081 §3.1.3)
 	Ackno  uint32 // only meaningful for SEQ frames
 	Window uint32 // only meaningful for SEQ frames
 }
 
+const (
+	// maxInt31 is the maximum value for channel, msgno, size, and ansno
+	// per RFC 3080 §2.2.1 ABNF (0..2147483647).
+	maxInt31 = 2147483647
+
+	// maxHeaderLen caps the frame header line length to prevent unbounded
+	// buffering from a malicious sender that never sends a newline.
+	maxHeaderLen = 128
+
+	// DefaultMaxPayloadSize is the default maximum payload size (2 MB).
+	// Callers can override via ScannerOption.
+	DefaultMaxPayloadSize = 2 * 1024 * 1024
+)
+
 // Scanner reads BEEP frames from an io.Reader.
 type Scanner struct {
-	r *bufio.Reader
+	r              *bufio.Reader
+	maxPayloadSize int
+}
+
+// ScannerOption configures a Scanner.
+type ScannerOption func(*Scanner)
+
+// WithMaxPayloadSize sets the maximum payload size the scanner will allocate.
+// Frames declaring a size larger than this are rejected with an error.
+// A value of 0 means no limit (not recommended for untrusted input).
+func WithMaxPayloadSize(n int) ScannerOption {
+	return func(s *Scanner) {
+		s.maxPayloadSize = n
+	}
 }
 
 // NewScanner creates a Scanner that reads BEEP frames from r.
-func NewScanner(r io.Reader) *Scanner {
+func NewScanner(r io.Reader, opts ...ScannerOption) *Scanner {
 	br, ok := r.(*bufio.Reader)
 	if !ok {
-		br = bufio.NewReader(r)
+		br = bufio.NewReaderSize(r, maxHeaderLen)
 	}
-	return &Scanner{r: br}
+	s := &Scanner{
+		r:              br,
+		maxPayloadSize: DefaultMaxPayloadSize,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Scan reads the next BEEP frame from the underlying reader.
@@ -77,6 +114,11 @@ func (s *Scanner) Scan() (Frame, error) {
 			return Frame{}, io.EOF
 		}
 		return Frame{}, fmt.Errorf("reading frame header: %w", err)
+	}
+
+	// Reject excessively long header lines
+	if len(line) > maxHeaderLen {
+		return Frame{}, fmt.Errorf("frame header too long (%d bytes, max %d)", len(line), maxHeaderLen)
 	}
 
 	// Strip trailing CRLF
@@ -110,7 +152,7 @@ func (s *Scanner) parseSEQ(fields [][]byte) (Frame, error) {
 		return Frame{}, fmt.Errorf("SEQ frame requires 4 fields, got %d", len(fields))
 	}
 
-	channel, err := parseUint32(fields[1], "channel")
+	channel, err := parseInt31(fields[1], "channel")
 	if err != nil {
 		return Frame{}, err
 	}
@@ -142,11 +184,11 @@ func (s *Scanner) parseDataFrame(ft FrameType, fields [][]byte) (Frame, error) {
 		return Frame{}, fmt.Errorf("%s frame requires %d fields, got %d", ft, expectedFields, len(fields))
 	}
 
-	channel, err := parseUint32(fields[1], "channel")
+	channel, err := parseInt31(fields[1], "channel")
 	if err != nil {
 		return Frame{}, err
 	}
-	msgno, err := parseUint32(fields[2], "msgno")
+	msgno, err := parseInt31(fields[2], "msgno")
 	if err != nil {
 		return Frame{}, err
 	}
@@ -160,22 +202,38 @@ func (s *Scanner) parseDataFrame(ft FrameType, fields [][]byte) (Frame, error) {
 	if err != nil {
 		return Frame{}, err
 	}
-	size, err := parseUint32(fields[5], "size")
+	size, err := parseInt31(fields[5], "size")
 	if err != nil {
 		return Frame{}, err
 	}
 
 	var ansno uint32
 	if ft == FrameANS {
-		ansno, err = parseUint32(fields[6], "ansno")
+		ansno, err = parseInt31(fields[6], "ansno")
 		if err != nil {
 			return Frame{}, err
 		}
 	}
 
-	// Read exactly 'size' bytes of payload
-	payload := make([]byte, size)
+	// RFC 3080 §2.2.1: NUL frames must have continuation='.' and size=0
+	if ft == FrameNUL {
+		if more {
+			return Frame{}, fmt.Errorf("NUL frame must have continuation '.', got '*'")
+		}
+		if size != 0 {
+			return Frame{}, fmt.Errorf("NUL frame must have size 0, got %d", size)
+		}
+	}
+
+	// Reject payloads exceeding the configured limit before allocating
+	if s.maxPayloadSize > 0 && int(size) > s.maxPayloadSize {
+		return Frame{}, fmt.Errorf("frame payload size %d exceeds max %d", size, s.maxPayloadSize)
+	}
+
+	// Read exactly 'size' bytes of payload; nil when size is 0
+	var payload []byte
 	if size > 0 {
+		payload = make([]byte, size)
 		if _, err := io.ReadFull(s.r, payload); err != nil {
 			return Frame{}, fmt.Errorf("reading payload (%d bytes): %w", size, err)
 		}
@@ -202,6 +260,21 @@ func (s *Scanner) parseDataFrame(ft FrameType, fields [][]byte) (Frame, error) {
 	}, nil
 }
 
+// parseInt31 parses a uint value in the range 0..2147483647 (2^31-1).
+// RFC 3080 §2.2.1 uses this range for channel, msgno, size, and ansno.
+func parseInt31(b []byte, name string) (uint32, error) {
+	v, err := strconv.ParseUint(string(b), 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", name, b, err)
+	}
+	if v > maxInt31 {
+		return 0, fmt.Errorf("invalid %s %q: value %d exceeds max %d", name, b, v, maxInt31)
+	}
+	return uint32(v), nil
+}
+
+// parseUint32 parses a uint value in the range 0..4294967295.
+// Used for seqno (RFC 3080) and ackno/window (RFC 3081 §3.1.3).
 func parseUint32(b []byte, name string) (uint32, error) {
 	v, err := strconv.ParseUint(string(b), 10, 32)
 	if err != nil {

--- a/rfc3195/frame_test.go
+++ b/rfc3195/frame_test.go
@@ -1,0 +1,354 @@
+package rfc3195
+
+import (
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrameType_String(t *testing.T) {
+	tests := []struct {
+		ft   FrameType
+		want string
+	}{
+		{FrameMSG, "MSG"},
+		{FrameRPY, "RPY"},
+		{FrameERR, "ERR"},
+		{FrameANS, "ANS"},
+		{FrameNUL, "NUL"},
+		{FrameSEQ, "SEQ"},
+		{FrameType(99), "FrameType(99)"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, tt.ft.String())
+	}
+}
+
+func TestScan_MSG(t *testing.T) {
+	input := "MSG 0 1 . 0 11\r\nhello worldEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameMSG, f.Type)
+	assert.Equal(t, uint32(0), f.Channel)
+	assert.Equal(t, uint32(1), f.Msgno)
+	assert.False(t, f.More)
+	assert.Equal(t, uint32(0), f.Seqno)
+	assert.Equal(t, uint32(11), f.Size)
+	assert.Equal(t, []byte("hello world"), f.Payload)
+}
+
+func TestScan_RPY(t *testing.T) {
+	input := "RPY 1 2 . 100 2\r\nokEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameRPY, f.Type)
+	assert.Equal(t, uint32(1), f.Channel)
+	assert.Equal(t, uint32(2), f.Msgno)
+	assert.Equal(t, uint32(100), f.Seqno)
+	assert.Equal(t, uint32(2), f.Size)
+	assert.Equal(t, []byte("ok"), f.Payload)
+}
+
+func TestScan_ERR(t *testing.T) {
+	input := "ERR 0 0 . 0 5\r\noops!END\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameERR, f.Type)
+	assert.Equal(t, uint32(5), f.Size)
+	assert.Equal(t, []byte("oops!"), f.Payload)
+}
+
+func TestScan_ANS(t *testing.T) {
+	input := "ANS 1 0 . 0 4 7\r\ndataEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameANS, f.Type)
+	assert.Equal(t, uint32(1), f.Channel)
+	assert.Equal(t, uint32(0), f.Msgno)
+	assert.Equal(t, uint32(4), f.Size)
+	assert.Equal(t, uint32(7), f.Ansno)
+	assert.Equal(t, []byte("data"), f.Payload)
+}
+
+func TestScan_NUL(t *testing.T) {
+	input := "NUL 1 0 . 0 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameNUL, f.Type)
+	assert.Equal(t, uint32(0), f.Size)
+	assert.Equal(t, []byte{}, f.Payload)
+}
+
+func TestScan_SEQ(t *testing.T) {
+	input := "SEQ 0 512 4096\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameSEQ, f.Type)
+	assert.Equal(t, uint32(0), f.Channel)
+	assert.Equal(t, uint32(512), f.Ackno)
+	assert.Equal(t, uint32(4096), f.Window)
+	assert.Nil(t, f.Payload)
+}
+
+func TestScan_MoreIndicator(t *testing.T) {
+	// '*' means intermediate (more frames follow)
+	input := "MSG 0 1 * 0 3\r\nfooEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.True(t, f.More)
+}
+
+func TestScan_MultipleFrames(t *testing.T) {
+	input := "MSG 0 0 . 0 5\r\nhelloEND\r\n" +
+		"SEQ 0 5 4096\r\n" +
+		"RPY 0 0 . 5 5\r\nworldEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+
+	f1, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameMSG, f1.Type)
+	assert.Equal(t, []byte("hello"), f1.Payload)
+
+	f2, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameSEQ, f2.Type)
+	assert.Equal(t, uint32(5), f2.Ackno)
+
+	f3, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameRPY, f3.Type)
+	assert.Equal(t, []byte("world"), f3.Payload)
+
+	_, err = s.Scan()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestScan_EOF(t *testing.T) {
+	s := NewScanner(strings.NewReader(""))
+	_, err := s.Scan()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestScan_PayloadWithNewlines(t *testing.T) {
+	// Payload containing CRLF — size-delimited, so newlines are part of payload
+	payload := "line1\r\nline2\r\n"
+	input := "MSG 0 0 . 0 14\r\n" + payload + "END\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, []byte(payload), f.Payload)
+}
+
+func TestScan_ZeroSizePayload(t *testing.T) {
+	input := "RPY 0 0 . 0 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0), f.Size)
+	assert.Equal(t, []byte{}, f.Payload)
+}
+
+// Error cases
+
+func TestScan_UnknownKeyword(t *testing.T) {
+	input := "FOO 0 0 . 0 0\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "unknown frame keyword")
+}
+
+func TestScan_MissingCRLF(t *testing.T) {
+	// Header terminated with just LF, no CR
+	input := "MSG 0 0 . 0 0\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "missing CRLF")
+}
+
+func TestScan_EmptyHeader(t *testing.T) {
+	input := "\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "empty frame header")
+}
+
+func TestScan_InvalidChannel(t *testing.T) {
+	input := "MSG abc 0 . 0 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "invalid channel")
+}
+
+func TestScan_InvalidMsgno(t *testing.T) {
+	input := "MSG 0 abc . 0 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "invalid msgno")
+}
+
+func TestScan_InvalidContinuation(t *testing.T) {
+	input := "MSG 0 0 x 0 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "invalid continuation")
+}
+
+func TestScan_InvalidSeqno(t *testing.T) {
+	input := "MSG 0 0 . abc 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "invalid seqno")
+}
+
+func TestScan_InvalidSize(t *testing.T) {
+	input := "MSG 0 0 . 0 abc\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "invalid size")
+}
+
+func TestScan_InvalidAnsno(t *testing.T) {
+	input := "ANS 0 0 . 0 0 abc\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "invalid ansno")
+}
+
+func TestScan_WrongFieldCount_MSG(t *testing.T) {
+	// MSG needs 6 fields, give it 5
+	input := "MSG 0 0 . 0\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "requires 6 fields")
+}
+
+func TestScan_WrongFieldCount_ANS(t *testing.T) {
+	// ANS needs 7 fields, give it 6
+	input := "ANS 0 0 . 0 0\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "requires 7 fields")
+}
+
+func TestScan_WrongFieldCount_SEQ(t *testing.T) {
+	// SEQ needs 4 fields, give it 3
+	input := "SEQ 0 512\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "requires 4 fields")
+}
+
+func TestScan_SEQ_InvalidAckno(t *testing.T) {
+	input := "SEQ 0 abc 4096\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "invalid ackno")
+}
+
+func TestScan_SEQ_InvalidWindow(t *testing.T) {
+	input := "SEQ 0 512 abc\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "invalid window")
+}
+
+func TestScan_SEQ_InvalidChannel(t *testing.T) {
+	input := "SEQ abc 512 4096\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "invalid channel")
+}
+
+func TestScan_TruncatedPayload(t *testing.T) {
+	// Declare size=10 but only provide 3 bytes before EOF
+	input := "MSG 0 0 . 0 10\r\nfoo"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "reading payload")
+}
+
+func TestScan_MissingENDTrailer(t *testing.T) {
+	input := "MSG 0 0 . 0 3\r\nfooXX\r\n\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "expected END trailer")
+}
+
+func TestScan_TruncatedENDTrailer(t *testing.T) {
+	// Payload is correct but END trailer is truncated
+	input := "MSG 0 0 . 0 3\r\nfooEN"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "reading END trailer")
+}
+
+func TestScan_InvalidContinuation_MultiChar(t *testing.T) {
+	input := "MSG 0 0 .. 0 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "invalid continuation")
+}
+
+func TestScan_HeaderReadError(t *testing.T) {
+	// Partial header with no newline and EOF
+	input := "MSG 0 0 . 0 5"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "reading frame header")
+}
+
+func TestScan_LargePayload(t *testing.T) {
+	payload := strings.Repeat("A", 4096)
+	input := "MSG 0 0 . 0 4096\r\n" + payload + "END\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, 4096, len(f.Payload))
+	assert.Equal(t, []byte(payload), f.Payload)
+}
+
+func TestNewScanner_WithBufioReader(t *testing.T) {
+	// Verify that passing a *bufio.Reader doesn't double-wrap
+	r := strings.NewReader("SEQ 0 0 4096\r\n")
+	br := NewScanner(r)
+	f, err := br.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameSEQ, f.Type)
+}
+
+func TestScan_ExtraFieldsOnMSG(t *testing.T) {
+	// MSG with 7 fields (extra field) should fail
+	input := "MSG 0 0 . 0 0 99\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "requires 6 fields")
+}
+
+func TestScan_SEQ_ExtraFields(t *testing.T) {
+	input := "SEQ 0 512 4096 extra\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "requires 4 fields")
+}
+
+func TestScan_PayloadContainingEND(t *testing.T) {
+	// Payload that contains "END\r\n" — size-delimited, so scanner should not be confused
+	payload := "END\r\nEND\r\n"
+	size := len(payload)
+	input := "MSG 0 0 . 0 " + strconv.Itoa(size) + "\r\n" + payload + "END\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, []byte(payload), f.Payload)
+}

--- a/rfc3195/frame_test.go
+++ b/rfc3195/frame_test.go
@@ -1,6 +1,7 @@
 package rfc3195
 
 import (
+	"bufio"
 	"io"
 	"strconv"
 	"strings"
@@ -85,7 +86,7 @@ func TestScan_NUL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, FrameNUL, f.Type)
 	assert.Equal(t, uint32(0), f.Size)
-	assert.Equal(t, []byte{}, f.Payload)
+	assert.Nil(t, f.Payload) // zero-size payload is nil, not []byte{}
 }
 
 func TestScan_SEQ(t *testing.T) {
@@ -101,7 +102,6 @@ func TestScan_SEQ(t *testing.T) {
 }
 
 func TestScan_MoreIndicator(t *testing.T) {
-	// '*' means intermediate (more frames follow)
 	input := "MSG 0 1 * 0 3\r\nfooEND\r\n"
 	s := NewScanner(strings.NewReader(input))
 	f, err := s.Scan()
@@ -141,7 +141,6 @@ func TestScan_EOF(t *testing.T) {
 }
 
 func TestScan_PayloadWithNewlines(t *testing.T) {
-	// Payload containing CRLF — size-delimited, so newlines are part of payload
 	payload := "line1\r\nline2\r\n"
 	input := "MSG 0 0 . 0 14\r\n" + payload + "END\r\n"
 	s := NewScanner(strings.NewReader(input))
@@ -156,7 +155,7 @@ func TestScan_ZeroSizePayload(t *testing.T) {
 	f, err := s.Scan()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(0), f.Size)
-	assert.Equal(t, []byte{}, f.Payload)
+	assert.Nil(t, f.Payload) // zero-size payload is nil, not []byte{}
 }
 
 // Error cases
@@ -169,7 +168,6 @@ func TestScan_UnknownKeyword(t *testing.T) {
 }
 
 func TestScan_MissingCRLF(t *testing.T) {
-	// Header terminated with just LF, no CR
 	input := "MSG 0 0 . 0 0\n"
 	s := NewScanner(strings.NewReader(input))
 	_, err := s.Scan()
@@ -226,7 +224,6 @@ func TestScan_InvalidAnsno(t *testing.T) {
 }
 
 func TestScan_WrongFieldCount_MSG(t *testing.T) {
-	// MSG needs 6 fields, give it 5
 	input := "MSG 0 0 . 0\r\n"
 	s := NewScanner(strings.NewReader(input))
 	_, err := s.Scan()
@@ -234,7 +231,6 @@ func TestScan_WrongFieldCount_MSG(t *testing.T) {
 }
 
 func TestScan_WrongFieldCount_ANS(t *testing.T) {
-	// ANS needs 7 fields, give it 6
 	input := "ANS 0 0 . 0 0\r\n"
 	s := NewScanner(strings.NewReader(input))
 	_, err := s.Scan()
@@ -242,7 +238,6 @@ func TestScan_WrongFieldCount_ANS(t *testing.T) {
 }
 
 func TestScan_WrongFieldCount_SEQ(t *testing.T) {
-	// SEQ needs 4 fields, give it 3
 	input := "SEQ 0 512\r\n"
 	s := NewScanner(strings.NewReader(input))
 	_, err := s.Scan()
@@ -271,7 +266,6 @@ func TestScan_SEQ_InvalidChannel(t *testing.T) {
 }
 
 func TestScan_TruncatedPayload(t *testing.T) {
-	// Declare size=10 but only provide 3 bytes before EOF
 	input := "MSG 0 0 . 0 10\r\nfoo"
 	s := NewScanner(strings.NewReader(input))
 	_, err := s.Scan()
@@ -286,7 +280,6 @@ func TestScan_MissingENDTrailer(t *testing.T) {
 }
 
 func TestScan_TruncatedENDTrailer(t *testing.T) {
-	// Payload is correct but END trailer is truncated
 	input := "MSG 0 0 . 0 3\r\nfooEN"
 	s := NewScanner(strings.NewReader(input))
 	_, err := s.Scan()
@@ -301,7 +294,6 @@ func TestScan_InvalidContinuation_MultiChar(t *testing.T) {
 }
 
 func TestScan_HeaderReadError(t *testing.T) {
-	// Partial header with no newline and EOF
 	input := "MSG 0 0 . 0 5"
 	s := NewScanner(strings.NewReader(input))
 	_, err := s.Scan()
@@ -318,17 +310,7 @@ func TestScan_LargePayload(t *testing.T) {
 	assert.Equal(t, []byte(payload), f.Payload)
 }
 
-func TestNewScanner_WithBufioReader(t *testing.T) {
-	// Verify that passing a *bufio.Reader doesn't double-wrap
-	r := strings.NewReader("SEQ 0 0 4096\r\n")
-	br := NewScanner(r)
-	f, err := br.Scan()
-	require.NoError(t, err)
-	assert.Equal(t, FrameSEQ, f.Type)
-}
-
 func TestScan_ExtraFieldsOnMSG(t *testing.T) {
-	// MSG with 7 fields (extra field) should fail
 	input := "MSG 0 0 . 0 0 99\r\nEND\r\n"
 	s := NewScanner(strings.NewReader(input))
 	_, err := s.Scan()
@@ -343,7 +325,6 @@ func TestScan_SEQ_ExtraFields(t *testing.T) {
 }
 
 func TestScan_PayloadContainingEND(t *testing.T) {
-	// Payload that contains "END\r\n" — size-delimited, so scanner should not be confused
 	payload := "END\r\nEND\r\n"
 	size := len(payload)
 	input := "MSG 0 0 . 0 " + strconv.Itoa(size) + "\r\n" + payload + "END\r\n"
@@ -351,4 +332,135 @@ func TestScan_PayloadContainingEND(t *testing.T) {
 	f, err := s.Scan()
 	require.NoError(t, err)
 	assert.Equal(t, []byte(payload), f.Payload)
+}
+
+// Fix #11: pass an actual *bufio.Reader to exercise the non-wrapping path
+func TestNewScanner_WithBufioReader(t *testing.T) {
+	br := bufio.NewReader(strings.NewReader("SEQ 0 0 4096\r\n"))
+	s := NewScanner(br)
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, FrameSEQ, f.Type)
+}
+
+// Fix #1: parseInt31 rejects values > 2^31-1 for channel, msgno, size, ansno
+
+func TestScan_ChannelExceedsInt31(t *testing.T) {
+	// 2147483648 = 2^31, one above max
+	input := "MSG 2147483648 0 . 0 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "exceeds max")
+}
+
+func TestScan_MsgnoExceedsInt31(t *testing.T) {
+	input := "MSG 0 2147483648 . 0 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "exceeds max")
+}
+
+func TestScan_SizeExceedsInt31(t *testing.T) {
+	input := "MSG 0 0 . 0 2147483648\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "exceeds max")
+}
+
+func TestScan_AnsnoExceedsInt31(t *testing.T) {
+	input := "ANS 0 0 . 0 0 2147483648\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "exceeds max")
+}
+
+func TestScan_SEQ_ChannelExceedsInt31(t *testing.T) {
+	input := "SEQ 2147483648 0 4096\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "exceeds max")
+}
+
+func TestScan_Int31MaxAccepted(t *testing.T) {
+	// 2147483647 = 2^31-1, exactly at max — should succeed
+	input := "MSG 2147483647 2147483647 . 0 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2147483647), f.Channel)
+	assert.Equal(t, uint32(2147483647), f.Msgno)
+}
+
+// seqno and ackno/window are full uint32 — verify max uint32 is accepted
+
+func TestScan_SeqnoMaxUint32(t *testing.T) {
+	input := "MSG 0 0 . 4294967295 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(4294967295), f.Seqno)
+}
+
+func TestScan_SEQ_AcknoMaxUint32(t *testing.T) {
+	input := "SEQ 0 4294967295 4294967295\r\n"
+	s := NewScanner(strings.NewReader(input))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(4294967295), f.Ackno)
+	assert.Equal(t, uint32(4294967295), f.Window)
+}
+
+// Fix #2: max payload size
+
+func TestScan_PayloadExceedsMaxSize(t *testing.T) {
+	input := "MSG 0 0 . 0 1000\r\n" + strings.Repeat("A", 1000) + "END\r\n"
+	s := NewScanner(strings.NewReader(input), WithMaxPayloadSize(100))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "exceeds max")
+}
+
+func TestScan_PayloadAtMaxSize(t *testing.T) {
+	payload := strings.Repeat("A", 100)
+	input := "MSG 0 0 . 0 100\r\n" + payload + "END\r\n"
+	s := NewScanner(strings.NewReader(input), WithMaxPayloadSize(100))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, []byte(payload), f.Payload)
+}
+
+func TestScan_MaxPayloadSizeZeroMeansNoLimit(t *testing.T) {
+	payload := strings.Repeat("A", 4096)
+	input := "MSG 0 0 . 0 4096\r\n" + payload + "END\r\n"
+	s := NewScanner(strings.NewReader(input), WithMaxPayloadSize(0))
+	f, err := s.Scan()
+	require.NoError(t, err)
+	assert.Equal(t, 4096, len(f.Payload))
+}
+
+// Fix #6: NUL frame validation
+
+func TestScan_NUL_IntermediateContinuation(t *testing.T) {
+	// NUL with '*' continuation is a poorly-formed frame per RFC 3080 §2.2.1
+	input := "NUL 0 0 * 0 0\r\nEND\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "NUL frame must have continuation '.'")
+}
+
+func TestScan_NUL_NonZeroSize(t *testing.T) {
+	// NUL with size > 0 is a poorly-formed frame per RFC 3080 §2.2.1
+	input := "NUL 0 0 . 0 5\r\noops!END\r\n"
+	s := NewScanner(strings.NewReader(input))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "NUL frame must have size 0")
+}
+
+// Fix #7: header too long
+
+func TestScan_HeaderTooLong(t *testing.T) {
+	// Build a header line longer than maxHeaderLen (128 bytes)
+	long := "MSG 0 0 . 0 0" + strings.Repeat(" ", 200) + "\r\n"
+	s := NewScanner(strings.NewReader(long))
+	_, err := s.Scan()
+	assert.ErrorContains(t, err, "header too long")
 }

--- a/rfc3195/raw.go
+++ b/rfc3195/raw.go
@@ -115,12 +115,19 @@ func (p *parser) Parse(r io.Reader) {
 			// End of exchange
 			return
 
+		case FrameERR:
+			// Server signaling an error condition (RFC 3195 §4.2)
+			p.emit(&syslog.Result{
+				Error: fmt.Errorf("rfc3195 raw: received ERR frame: %s", frame.Payload),
+			})
+			return
+
 		case FrameSEQ:
 			// Flow control — skip silently
 			continue
 
 		default:
-			// MSG, RPY, ERR frames are not expected in RAW profile data flow
+			// MSG, RPY frames are not expected in RAW profile data flow
 			// but we skip them rather than aborting
 			continue
 		}
@@ -141,10 +148,8 @@ func (p *parser) processANS(frame Frame) {
 
 	msg, err := p.internal.Parse(payload)
 	result := &syslog.Result{Message: msg, Error: err}
-
-	if p.bestEffort || err == nil {
-		p.emit(result)
-	} else {
-		p.emit(&syslog.Result{Error: err})
+	if !p.bestEffort && err != nil {
+		result.Message = nil
 	}
+	p.emit(result)
 }

--- a/rfc3195/raw.go
+++ b/rfc3195/raw.go
@@ -89,7 +89,11 @@ func (p *parser) WithListener(f syslog.ParserListener) {
 // A NUL frame signals the end of the exchange. SEQ frames are silently skipped
 // (flow control is not relevant for parsing-only use).
 func (p *parser) Parse(r io.Reader) {
-	scanner := NewScanner(r)
+	var scanOpts []ScannerOption
+	if p.maxMessageLength > 0 {
+		scanOpts = append(scanOpts, WithMaxPayloadSize(p.maxMessageLength))
+	}
+	scanner := NewScanner(r, scanOpts...)
 
 	for {
 		frame, err := scanner.Scan()
@@ -128,15 +132,8 @@ func (p *parser) Parse(r io.Reader) {
 func (p *parser) processANS(frame Frame) {
 	payload := frame.Payload
 
-	if p.maxMessageLength > 0 && len(payload) > p.maxMessageLength {
-		p.emit(&syslog.Result{
-			Error: fmt.Errorf("rfc3195 raw: message length %d exceeds max %d", len(payload), p.maxMessageLength),
-		})
-		return
-	}
-
-	// Strip trailing CRLF (framing artifact, not part of the syslog message)
-	payload = bytes.TrimRight(payload, "\r\n")
+	// Strip exactly one trailing CRLF (framing artifact, not part of the syslog message)
+	payload = bytes.TrimSuffix(payload, []byte("\r\n"))
 
 	if len(payload) == 0 {
 		return

--- a/rfc3195/raw.go
+++ b/rfc3195/raw.go
@@ -1,0 +1,153 @@
+package rfc3195
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	syslog "github.com/leodido/go-syslog/v4"
+	"github.com/leodido/go-syslog/v4/rfc3164"
+	"github.com/leodido/go-syslog/v4/rfc5424"
+)
+
+// RAW profile (RFC 3195 §4.2): syslog messages arrive as ANS frame payloads,
+// each terminated by CRLF. A NUL frame signals end of the exchange.
+
+// parser implements syslog.Parser for the RFC 3195 RAW profile.
+type parser struct {
+	bestEffort       bool
+	maxMessageLength int
+	internal         syslog.Machine
+	internalOpts     []syslog.MachineOption
+	emit             syslog.ParserListener
+}
+
+// NewParser returns a syslog.Parser for the RFC 3195 RAW profile using RFC 5424 message format.
+func NewParser(opts ...syslog.ParserOption) syslog.Parser {
+	p := &parser{
+		emit:             func(*syslog.Result) { /* noop */ },
+		maxMessageLength: 0, // 0 = no limit
+	}
+
+	for _, opt := range opts {
+		p = opt(p).(*parser)
+	}
+
+	if p.bestEffort {
+		p.internalOpts = append(p.internalOpts, rfc5424.WithBestEffort())
+	}
+
+	p.internal = rfc5424.NewMachine(p.internalOpts...)
+
+	return p
+}
+
+// NewParserRFC3164 returns a syslog.Parser for the RFC 3195 RAW profile using RFC 3164 message format.
+func NewParserRFC3164(opts ...syslog.ParserOption) syslog.Parser {
+	p := &parser{
+		emit:             func(*syslog.Result) { /* noop */ },
+		maxMessageLength: 0,
+	}
+
+	for _, opt := range opts {
+		p = opt(p).(*parser)
+	}
+
+	if p.bestEffort {
+		p.internalOpts = append(p.internalOpts, rfc3164.WithBestEffort())
+	}
+
+	p.internal = rfc3164.NewMachine(p.internalOpts...)
+
+	return p
+}
+
+func (p *parser) WithBestEffort() {
+	p.bestEffort = true
+}
+
+func (p *parser) HasBestEffort() bool {
+	return p.bestEffort
+}
+
+func (p *parser) WithMachineOptions(opts ...syslog.MachineOption) {
+	p.internalOpts = append(p.internalOpts, opts...)
+}
+
+func (p *parser) WithMaxMessageLength(length int) {
+	p.maxMessageLength = length
+}
+
+func (p *parser) WithListener(f syslog.ParserListener) {
+	p.emit = f
+}
+
+// Parse reads BEEP frames from r and emits parsed syslog messages.
+//
+// Per RFC 3195 §4.2, the RAW profile carries syslog messages in ANS frame
+// payloads. Each payload contains a single syslog message terminated by CRLF.
+// A NUL frame signals the end of the exchange. SEQ frames are silently skipped
+// (flow control is not relevant for parsing-only use).
+func (p *parser) Parse(r io.Reader) {
+	scanner := NewScanner(r)
+
+	for {
+		frame, err := scanner.Scan()
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			p.emit(&syslog.Result{
+				Error: fmt.Errorf("rfc3195 raw: frame scan error: %w", err),
+			})
+			return
+		}
+
+		switch frame.Type {
+		case FrameANS:
+			p.processANS(frame)
+
+		case FrameNUL:
+			// End of exchange
+			return
+
+		case FrameSEQ:
+			// Flow control — skip silently
+			continue
+
+		default:
+			// MSG, RPY, ERR frames are not expected in RAW profile data flow
+			// but we skip them rather than aborting
+			continue
+		}
+	}
+}
+
+// processANS extracts the syslog message from an ANS frame payload.
+// Per RFC 3195 §4.2, the payload is a syslog message terminated by CRLF.
+func (p *parser) processANS(frame Frame) {
+	payload := frame.Payload
+
+	if p.maxMessageLength > 0 && len(payload) > p.maxMessageLength {
+		p.emit(&syslog.Result{
+			Error: fmt.Errorf("rfc3195 raw: message length %d exceeds max %d", len(payload), p.maxMessageLength),
+		})
+		return
+	}
+
+	// Strip trailing CRLF (framing artifact, not part of the syslog message)
+	payload = bytes.TrimRight(payload, "\r\n")
+
+	if len(payload) == 0 {
+		return
+	}
+
+	msg, err := p.internal.Parse(payload)
+	result := &syslog.Result{Message: msg, Error: err}
+
+	if p.bestEffort || err == nil {
+		p.emit(result)
+	} else {
+		p.emit(&syslog.Result{Error: err})
+	}
+}

--- a/rfc3195/raw_test.go
+++ b/rfc3195/raw_test.go
@@ -1,0 +1,338 @@
+package rfc3195
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	syslog "github.com/leodido/go-syslog/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// beepFrame builds a raw BEEP data frame string.
+// For ANS frames, pass ansno >= 0. For other types, ansno is ignored.
+func beepFrame(keyword string, channel, msgno int, more byte, seqno, size int, ansno int, payload string) string {
+	header := fmt.Sprintf("%s %d %d %c %d %d", keyword, channel, msgno, more, seqno, size)
+	if keyword == "ANS" {
+		header += " " + strconv.Itoa(ansno)
+	}
+	return header + "\r\n" + payload + "END\r\n"
+}
+
+func seqFrame(channel, ackno, window int) string {
+	return fmt.Sprintf("SEQ %d %d %d\r\n", channel, ackno, window)
+}
+
+// A minimal valid RFC 5424 message
+const validRFC5424 = "<1>1 - - - - - -"
+
+// A minimal valid RFC 3164 message
+const validRFC3164 = "<34>Oct 11 22:14:15 mymachine su: test"
+
+func TestRawParser_SingleMessage_RFC5424(t *testing.T) {
+	payload := validRFC5424 + "\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	assert.NotNil(t, results[0].Message)
+	assert.True(t, results[0].Message.Valid())
+}
+
+func TestRawParser_SingleMessage_RFC3164(t *testing.T) {
+	payload := validRFC3164 + "\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+
+	var results []*syslog.Result
+	p := NewParserRFC3164(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	assert.NotNil(t, results[0].Message)
+	assert.True(t, results[0].Message.Valid())
+}
+
+func TestRawParser_MultipleMessages(t *testing.T) {
+	msg1 := "<1>1 - - - - - -\r\n"
+	msg2 := "<2>1 - - - - - -\r\n"
+	seq := len(msg1)
+	input := beepFrame("ANS", 1, 0, '.', 0, len(msg1), 0, msg1) +
+		beepFrame("ANS", 1, 0, '.', seq, len(msg2), 1, msg2) +
+		"NUL 1 0 . " + strconv.Itoa(seq+len(msg2)) + " 0\r\nEND\r\n"
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 2)
+	for i, r := range results {
+		assert.NoError(t, r.Error, "message %d", i)
+		assert.NotNil(t, r.Message, "message %d", i)
+	}
+}
+
+func TestRawParser_SEQFramesSkipped(t *testing.T) {
+	payload := validRFC5424 + "\r\n"
+	input := seqFrame(0, 0, 4096) +
+		beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		seqFrame(1, len(payload), 4096) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+}
+
+func TestRawParser_NULTerminates(t *testing.T) {
+	payload := validRFC5424 + "\r\n"
+	// NUL before second ANS — second message should not be emitted
+	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n" +
+		beepFrame("ANS", 1, 0, '.', 0, len(payload), 1, payload)
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+}
+
+func TestRawParser_EOFWithoutNUL(t *testing.T) {
+	// Stream ends without NUL — parser should still emit the message
+	payload := validRFC5424 + "\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload)
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+}
+
+func TestRawParser_EmptyPayload(t *testing.T) {
+	// ANS with only CRLF payload — should be skipped (empty after stripping)
+	input := beepFrame("ANS", 1, 0, '.', 0, 2, 0, "\r\n") +
+		"NUL 1 0 . 2 0\r\nEND\r\n"
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	assert.Len(t, results, 0)
+}
+
+func TestRawParser_ZeroSizePayload(t *testing.T) {
+	// ANS with zero-size payload — should be skipped
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, 0, "") +
+		"NUL 1 0 . 0 0\r\nEND\r\n"
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	assert.Len(t, results, 0)
+}
+
+func TestRawParser_InvalidSyslogMessage_Strict(t *testing.T) {
+	// Invalid syslog message (no priority) — strict mode should emit error only
+	payload := "not a syslog message\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+	assert.Nil(t, results[0].Message)
+}
+
+func TestRawParser_InvalidSyslogMessage_BestEffort(t *testing.T) {
+	// Invalid syslog message with best effort — should emit partial result
+	payload := "not a syslog message\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+
+	var results []*syslog.Result
+	p := NewParser(
+		syslog.WithBestEffort(),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+	// Best effort still emits the result (with error)
+}
+
+func TestRawParser_MaxMessageLength(t *testing.T) {
+	payload := validRFC5424 + "\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+
+	var results []*syslog.Result
+	p := NewParser(
+		syslog.WithMaxMessageLength(5), // too small
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.ErrorContains(t, results[0].Error, "exceeds max")
+}
+
+func TestRawParser_FrameScanError(t *testing.T) {
+	// Malformed frame header
+	input := "INVALID\r\n"
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.ErrorContains(t, results[0].Error, "frame scan error")
+}
+
+func TestRawParser_UnexpectedFrameTypesSkipped(t *testing.T) {
+	// MSG and RPY frames should be skipped, only ANS processed
+	payload := validRFC5424 + "\r\n"
+	input := "MSG 0 0 . 0 5\r\nhelloEND\r\n" +
+		"RPY 0 0 . 5 2\r\nokEND\r\n" +
+		beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+}
+
+func TestRawParser_EmptyStream(t *testing.T) {
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(""))
+
+	assert.Len(t, results, 0)
+}
+
+func TestRawParser_HasBestEffort(t *testing.T) {
+	p := NewParser()
+	assert.False(t, p.HasBestEffort())
+
+	p2 := NewParser(syslog.WithBestEffort())
+	assert.True(t, p2.HasBestEffort())
+}
+
+func TestRawParserRFC3164_HasBestEffort(t *testing.T) {
+	p := NewParserRFC3164()
+	assert.False(t, p.HasBestEffort())
+
+	p2 := NewParserRFC3164(syslog.WithBestEffort())
+	assert.True(t, p2.HasBestEffort())
+}
+
+func TestRawParser_WithMachineOptions(t *testing.T) {
+	// Verify that machine options are passed through via WithMachineOptions
+	payload := validRFC5424 + "\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+
+	noopOpt := func(m syslog.Machine) syslog.Machine { return m }
+
+	var results []*syslog.Result
+	p := NewParser(
+		syslog.WithMachineOptions(noopOpt),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+}
+
+func TestRawParser_DefaultListener(t *testing.T) {
+	// Verify default noop listener doesn't panic
+	payload := validRFC5424 + "\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+
+	p := NewParser()
+	assert.NotPanics(t, func() {
+		p.Parse(strings.NewReader(input))
+	})
+}
+
+func TestRawParserRFC3164_DefaultListener(t *testing.T) {
+	p := NewParserRFC3164()
+	payload := validRFC3164 + "\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+
+	assert.NotPanics(t, func() {
+		p.Parse(strings.NewReader(input))
+	})
+}
+
+// Verify the parser satisfies syslog.Parser at compile time
+var _ syslog.Parser = (*parser)(nil)

--- a/rfc3195/raw_test.go
+++ b/rfc3195/raw_test.go
@@ -259,7 +259,29 @@ func TestRawParser_FrameScanError(t *testing.T) {
 	assert.ErrorContains(t, results[0].Error, "frame scan error")
 }
 
+func TestRawParser_ERRFrameEmitsError(t *testing.T) {
+	// ERR frame signals server error — parser should emit error and stop
+	payload := validRFC5424 + "\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		"ERR 1 0 . " + strconv.Itoa(len(payload)) + " 12\r\nserver errorEND\r\n" +
+		beepFrame("ANS", 1, 0, '.', len(payload), 1, payload)
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	// First ANS emitted, then ERR terminates — second ANS never reached
+	require.Len(t, results, 2)
+	assert.NoError(t, results[0].Error)
+	assert.ErrorContains(t, results[1].Error, "ERR frame")
+	assert.ErrorContains(t, results[1].Error, "server error")
+}
+
 func TestRawParser_UnexpectedFrameTypesSkipped(t *testing.T) {
+	// MSG and RPY frames are skipped (ERR is handled separately)
 	payload := validRFC5424 + "\r\n"
 	input := "MSG 0 0 . 0 5\r\nhelloEND\r\n" +
 		"RPY 0 0 . 5 2\r\nokEND\r\n" +

--- a/rfc3195/raw_test.go
+++ b/rfc3195/raw_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 // beepFrame builds a raw BEEP data frame string.
+// Size is computed automatically from len(payload).
 // For ANS frames, pass ansno >= 0. For other types, ansno is ignored.
-func beepFrame(keyword string, channel, msgno int, more byte, seqno, size int, ansno int, payload string) string {
+func beepFrame(keyword string, channel, msgno int, more byte, seqno int, ansno int, payload string) string {
+	size := len(payload)
 	header := fmt.Sprintf("%s %d %d %c %d %d", keyword, channel, msgno, more, seqno, size)
 	if keyword == "ANS" {
 		header += " " + strconv.Itoa(ansno)
@@ -33,8 +35,8 @@ const validRFC3164 = "<34>Oct 11 22:14:15 mymachine su: test"
 
 func TestRawParser_SingleMessage_RFC5424(t *testing.T) {
 	payload := validRFC5424 + "\r\n"
-	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
 
 	var results []*syslog.Result
 	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
@@ -51,8 +53,8 @@ func TestRawParser_SingleMessage_RFC5424(t *testing.T) {
 
 func TestRawParser_SingleMessage_RFC3164(t *testing.T) {
 	payload := validRFC3164 + "\r\n"
-	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
 
 	var results []*syslog.Result
 	p := NewParserRFC3164(syslog.WithListener(func(r *syslog.Result) {
@@ -71,9 +73,9 @@ func TestRawParser_MultipleMessages(t *testing.T) {
 	msg1 := "<1>1 - - - - - -\r\n"
 	msg2 := "<2>1 - - - - - -\r\n"
 	seq := len(msg1)
-	input := beepFrame("ANS", 1, 0, '.', 0, len(msg1), 0, msg1) +
-		beepFrame("ANS", 1, 0, '.', seq, len(msg2), 1, msg2) +
-		"NUL 1 0 . " + strconv.Itoa(seq+len(msg2)) + " 0\r\nEND\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, msg1) +
+		beepFrame("ANS", 1, 0, '.', seq, 1, msg2) +
+		beepFrame("NUL", 1, 0, '.', seq+len(msg2), -1, "")
 
 	var results []*syslog.Result
 	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
@@ -92,9 +94,9 @@ func TestRawParser_MultipleMessages(t *testing.T) {
 func TestRawParser_SEQFramesSkipped(t *testing.T) {
 	payload := validRFC5424 + "\r\n"
 	input := seqFrame(0, 0, 4096) +
-		beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
+		beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
 		seqFrame(1, len(payload), 4096) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
 
 	var results []*syslog.Result
 	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
@@ -110,9 +112,9 @@ func TestRawParser_SEQFramesSkipped(t *testing.T) {
 func TestRawParser_NULTerminates(t *testing.T) {
 	payload := validRFC5424 + "\r\n"
 	// NUL before second ANS — second message should not be emitted
-	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n" +
-		beepFrame("ANS", 1, 0, '.', 0, len(payload), 1, payload)
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "") +
+		beepFrame("ANS", 1, 0, '.', 0, 1, payload)
 
 	var results []*syslog.Result
 	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
@@ -125,9 +127,8 @@ func TestRawParser_NULTerminates(t *testing.T) {
 }
 
 func TestRawParser_EOFWithoutNUL(t *testing.T) {
-	// Stream ends without NUL — parser should still emit the message
 	payload := validRFC5424 + "\r\n"
-	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload)
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload)
 
 	var results []*syslog.Result
 	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
@@ -140,10 +141,10 @@ func TestRawParser_EOFWithoutNUL(t *testing.T) {
 	assert.NoError(t, results[0].Error)
 }
 
-func TestRawParser_EmptyPayload(t *testing.T) {
-	// ANS with only CRLF payload — should be skipped (empty after stripping)
-	input := beepFrame("ANS", 1, 0, '.', 0, 2, 0, "\r\n") +
-		"NUL 1 0 . 2 0\r\nEND\r\n"
+func TestRawParser_EmptyPayload_OnlyCRLF(t *testing.T) {
+	// ANS with only CRLF payload — should be skipped (empty after stripping one CRLF)
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, "\r\n") +
+		beepFrame("NUL", 1, 0, '.', 2, -1, "")
 
 	var results []*syslog.Result
 	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
@@ -156,9 +157,8 @@ func TestRawParser_EmptyPayload(t *testing.T) {
 }
 
 func TestRawParser_ZeroSizePayload(t *testing.T) {
-	// ANS with zero-size payload — should be skipped
-	input := beepFrame("ANS", 1, 0, '.', 0, 0, 0, "") +
-		"NUL 1 0 . 0 0\r\nEND\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, "") +
+		beepFrame("NUL", 1, 0, '.', 0, -1, "")
 
 	var results []*syslog.Result
 	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
@@ -170,11 +170,30 @@ func TestRawParser_ZeroSizePayload(t *testing.T) {
 	assert.Len(t, results, 0)
 }
 
+func TestRawParser_TrimSuffix_NotTrimRight(t *testing.T) {
+	// Payload ending with \r\n\r\n — TrimSuffix strips exactly one CRLF,
+	// leaving \r\n which is passed to the syslog parser (and fails).
+	// TrimRight would have stripped all trailing CR/LF bytes.
+	payload := "not-syslog\r\n\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	// The remaining "not-syslog\r\n" is passed to the parser and fails
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+}
+
 func TestRawParser_InvalidSyslogMessage_Strict(t *testing.T) {
-	// Invalid syslog message (no priority) — strict mode should emit error only
 	payload := "not a syslog message\r\n"
-	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
 
 	var results []*syslog.Result
 	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
@@ -189,10 +208,9 @@ func TestRawParser_InvalidSyslogMessage_Strict(t *testing.T) {
 }
 
 func TestRawParser_InvalidSyslogMessage_BestEffort(t *testing.T) {
-	// Invalid syslog message with best effort — should emit partial result
 	payload := "not a syslog message\r\n"
-	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
 
 	var results []*syslog.Result
 	p := NewParser(
@@ -206,13 +224,12 @@ func TestRawParser_InvalidSyslogMessage_BestEffort(t *testing.T) {
 
 	require.Len(t, results, 1)
 	assert.Error(t, results[0].Error)
-	// Best effort still emits the result (with error)
 }
 
 func TestRawParser_MaxMessageLength(t *testing.T) {
 	payload := validRFC5424 + "\r\n"
-	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
 
 	var results []*syslog.Result
 	p := NewParser(
@@ -229,7 +246,6 @@ func TestRawParser_MaxMessageLength(t *testing.T) {
 }
 
 func TestRawParser_FrameScanError(t *testing.T) {
-	// Malformed frame header
 	input := "INVALID\r\n"
 
 	var results []*syslog.Result
@@ -244,12 +260,11 @@ func TestRawParser_FrameScanError(t *testing.T) {
 }
 
 func TestRawParser_UnexpectedFrameTypesSkipped(t *testing.T) {
-	// MSG and RPY frames should be skipped, only ANS processed
 	payload := validRFC5424 + "\r\n"
 	input := "MSG 0 0 . 0 5\r\nhelloEND\r\n" +
 		"RPY 0 0 . 5 2\r\nokEND\r\n" +
-		beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+		beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
 
 	var results []*syslog.Result
 	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
@@ -290,10 +305,9 @@ func TestRawParserRFC3164_HasBestEffort(t *testing.T) {
 }
 
 func TestRawParser_WithMachineOptions(t *testing.T) {
-	// Verify that machine options are passed through via WithMachineOptions
 	payload := validRFC5424 + "\r\n"
-	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
 
 	noopOpt := func(m syslog.Machine) syslog.Machine { return m }
 
@@ -312,10 +326,9 @@ func TestRawParser_WithMachineOptions(t *testing.T) {
 }
 
 func TestRawParser_DefaultListener(t *testing.T) {
-	// Verify default noop listener doesn't panic
 	payload := validRFC5424 + "\r\n"
-	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
 
 	p := NewParser()
 	assert.NotPanics(t, func() {
@@ -326,12 +339,50 @@ func TestRawParser_DefaultListener(t *testing.T) {
 func TestRawParserRFC3164_DefaultListener(t *testing.T) {
 	p := NewParserRFC3164()
 	payload := validRFC3164 + "\r\n"
-	input := beepFrame("ANS", 1, 0, '.', 0, len(payload), 0, payload) +
-		"NUL 1 0 . " + strconv.Itoa(len(payload)) + " 0\r\nEND\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
 
 	assert.NotPanics(t, func() {
 		p.Parse(strings.NewReader(input))
 	})
+}
+
+func TestRawParser_MaxMessageLengthPassedToScanner(t *testing.T) {
+	// When maxMessageLength is set, the scanner should reject oversized frames
+	// before the RAW parser even sees the payload
+	payload := validRFC5424 + "\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
+
+	var results []*syslog.Result
+	p := NewParser(
+		syslog.WithMaxMessageLength(5),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+}
+
+func TestRawParser_NoMaxMessageLength(t *testing.T) {
+	// When maxMessageLength is 0 (default), scanner uses DefaultMaxPayloadSize
+	payload := validRFC5424 + "\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
+
+	var results []*syslog.Result
+	p := NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
 }
 
 // Verify the parser satisfies syslog.Parser at compile time


### PR DESCRIPTION
Adds parsing-only support for RFC 3195 (Reliable Delivery for Syslog) — the BEEP frame scanner and RAW profile parser. PR 1 of 2 for #31; COOKED profile will follow.

No changes to `syslog.go` or existing packages.

## Commits

### `feat(rfc3195): add BEEP frame scanner`

Hand-written scanner for BEEP frames (RFC 3080 §2.2.1, RFC 3081 §3.1.3). Parses all six frame types: MSG, RPY, ERR, ANS, NUL, SEQ. Size-delimited — same approach as `octetcounting/`.

### `feat(rfc3195): add RAW profile parser`

Implements `syslog.Parser` for the RFC 3195 RAW profile. Extracts syslog messages from ANS frame payloads (CRLF-terminated per §4.2). Supports RFC 5424 (`NewParser`) and RFC 3164 (`NewParserRFC3164`), best-effort mode, and max message length. NUL terminates the exchange; SEQ frames silently skipped.

### `fix(rfc3195): frame scanner spec compliance and hardening`

- `parseInt31` enforces RFC 3080 range (0..2^31-1) for channel, msgno, size, ansno; `parseUint32` retained for seqno/ackno/window
- Configurable max payload size (default 2 MB) — rejects before allocating
- Header line length capped at 128 bytes to bound buffering
- NUL frames validated per spec: rejects `more='*'` or `size>0`
- Zero-size data frame payloads normalized to `nil` (consistent with SEQ)
- `bufio.NewReaderSize` for controlled initial buffer allocation

### `fix(rfc3195): RAW parser CRLF stripping and payload handling`

- `bytes.TrimSuffix` replaces `bytes.TrimRight` — strips exactly one trailing CRLF, not all trailing CR/LF bytes
- `maxMessageLength` passed through to scanner as `WithMaxPayloadSize`
- Redundant length check in `processANS` removed (scanner rejects first)
- Test helper `beepFrame` auto-computes size from payload length
- `TestNewScanner_WithBufioReader` exercises the `*bufio.Reader` passthrough path

### `fix(rfc3195): emit error on ERR frames, simplify processANS`

- ERR frames now emit a `syslog.Result` with the frame payload as the error message and terminate the parse loop (previously silently skipped)
- Strict-mode error path in `processANS` simplified: nils out `Message` on the existing `Result` instead of allocating a new one

## Design decisions

- **Parsing-only scope**: No BEEP session management. A future `go-beep` library could provide that.
- **Hand-written scanner**: BEEP framing is line-oriented and length-prefixed. Ragel would add complexity without benefit.
- **No external dependencies**: stdlib + existing go-syslog interfaces only.

## Coverage

100% statement coverage, 72 tests.

Refs: #31