### PR TITLE
feat(rfc3195): COOKED profile parser

### DIFF
--- a/rfc3195/cooked.go
+++ b/rfc3195/cooked.go
@@ -152,6 +152,9 @@ type xmlElement struct {
 }
 
 // xmlEntry maps to the <entry> element attributes per RFC 3195 §7 DTD.
+// The xml:lang attribute defined in the DTD is intentionally not captured:
+// encoding/xml silently ignores unmapped attributes, and language tagging
+// is not part of the syslog.Message contract.
 type xmlEntry struct {
 	XMLName    xml.Name `xml:""`
 	Facility   string   `xml:"facility,attr"`

--- a/rfc3195/cooked.go
+++ b/rfc3195/cooked.go
@@ -166,18 +166,21 @@ func (p *cookedParser) processPayload(payload []byte) {
 func (p *cookedParser) processEntry(entry xmlEntry) {
 	msg := &CookedMessage{}
 
-	// facility (required, 0-23)
+	// facility (required)
+	// DTD: %FACILITY = 1*3DIGIT. RFC 3195 examples use values beyond
+	// RFC 3164's 0-23 range (e.g., facility='80'). Accept 0-255 (uint8).
 	fac, err := strconv.Atoi(entry.Facility)
-	if err != nil || fac < 0 || fac > 23 {
+	if err != nil || fac < 0 || fac > 255 {
 		p.emitError(fmt.Errorf("rfc3195 cooked: invalid facility %q", entry.Facility), msg)
 		return
 	}
 	facU8 := uint8(fac)
 	msg.Facility = &facU8
 
-	// severity (required, 0-7)
+	// severity (required)
+	// DTD: %SEVERITY = DIGIT (0-9). Accept 0-9 per DTD.
 	sev, err := strconv.Atoi(entry.Severity)
-	if err != nil || sev < 0 || sev > 7 {
+	if err != nil || sev < 0 || sev > 9 {
 		p.emitError(fmt.Errorf("rfc3195 cooked: invalid severity %q", entry.Severity), msg)
 		return
 	}

--- a/rfc3195/cooked.go
+++ b/rfc3195/cooked.go
@@ -37,9 +37,12 @@ func WithRawElementListener(f RawElementListener) syslog.ParserOption {
 // WithCookedYear returns a parser option that sets the year for parsed
 // timestamps. RFC 3164 timestamps (used in COOKED <entry> elements) do
 // not include a year; without this option the year defaults to 0.
+// Values <= 0 are ignored (year remains 0).
 func WithCookedYear(year int) syslog.ParserOption {
 	return func(p syslog.Parser) syslog.Parser {
-		p.(*cookedParser).year = year
+		if year > 0 {
+			p.(*cookedParser).year = year
+		}
 		return p
 	}
 }

--- a/rfc3195/cooked.go
+++ b/rfc3195/cooked.go
@@ -248,7 +248,7 @@ func (p *cookedParser) processEntry(entry xmlEntry) {
 			return
 		}
 		if p.year > 0 {
-			t = t.AddDate(p.year, 0, 0)
+			t = time.Date(p.year, t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
 		}
 		msg.Timestamp = &t
 	}

--- a/rfc3195/cooked.go
+++ b/rfc3195/cooked.go
@@ -1,0 +1,239 @@
+package rfc3195
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	syslog "github.com/leodido/go-syslog/v4"
+)
+
+// COOKED profile (RFC 3195 §4.3): syslog messages arrive as <entry> XML
+// elements in BEEP frame payloads. Session metadata (<iam>, <path>, <ok/>)
+// can optionally be forwarded as raw XML bytes.
+
+// RawElementListener receives raw XML bytes for non-entry elements
+// (<iam>, <path>, <ok/>). elementName is the XML local name.
+type RawElementListener func(elementName string, rawXML []byte)
+
+// WithRawElementListener returns a parser option that sets a callback for
+// COOKED profile metadata elements (<iam>, <path>, <ok/>).
+//
+// The callback receives the element name and the raw XML bytes of the
+// element as they appeared in the BEEP frame payload. go-syslog does not
+// define Go types for these elements; a future go-beep library can
+// unmarshal them as needed.
+//
+// If not set, metadata elements are silently skipped.
+func WithRawElementListener(f RawElementListener) syslog.ParserOption {
+	return func(p syslog.Parser) syslog.Parser {
+		p.(*cookedParser).rawEmit = f
+		return p
+	}
+}
+
+// cookedParser implements syslog.Parser for the RFC 3195 COOKED profile.
+type cookedParser struct {
+	bestEffort       bool
+	maxMessageLength int
+	emit             syslog.ParserListener
+	rawEmit          RawElementListener
+}
+
+// NewCookedParser returns a syslog.Parser for the RFC 3195 COOKED profile.
+func NewCookedParser(opts ...syslog.ParserOption) syslog.Parser {
+	p := &cookedParser{
+		emit: func(*syslog.Result) { /* noop */ },
+	}
+
+	for _, opt := range opts {
+		p = opt(p).(*cookedParser)
+	}
+
+	return p
+}
+
+func (p *cookedParser) WithBestEffort() {
+	p.bestEffort = true
+}
+
+func (p *cookedParser) HasBestEffort() bool {
+	return p.bestEffort
+}
+
+func (p *cookedParser) WithMachineOptions(_ ...syslog.MachineOption) {
+	// No inner machine — COOKED parses XML attributes directly.
+	// Intentional no-op.
+}
+
+func (p *cookedParser) WithMaxMessageLength(length int) {
+	p.maxMessageLength = length
+}
+
+func (p *cookedParser) WithListener(f syslog.ParserListener) {
+	p.emit = f
+}
+
+// Parse reads BEEP frames from r and emits parsed syslog messages.
+//
+// Per RFC 3195 §4.3, the COOKED profile carries syslog messages as <entry>
+// XML elements in frame payloads. Metadata elements (<iam>, <path>, <ok/>)
+// are forwarded to the RawElementListener if set, otherwise silently skipped.
+func (p *cookedParser) Parse(r io.Reader) {
+	var scanOpts []ScannerOption
+	if p.maxMessageLength > 0 {
+		scanOpts = append(scanOpts, WithMaxPayloadSize(p.maxMessageLength))
+	}
+	scanner := NewScanner(r, scanOpts...)
+
+	for {
+		frame, err := scanner.Scan()
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			p.emit(&syslog.Result{
+				Error: fmt.Errorf("rfc3195 cooked: frame scan error: %w", err),
+			})
+			return
+		}
+
+		switch frame.Type {
+		case FrameANS, FrameMSG:
+			p.processPayload(frame.Payload)
+
+		case FrameNUL:
+			return
+
+		case FrameERR:
+			p.emit(&syslog.Result{
+				Error: fmt.Errorf("rfc3195 cooked: received ERR frame: %s", frame.Payload),
+			})
+			return
+
+		case FrameSEQ:
+			continue
+
+		default:
+			continue
+		}
+	}
+}
+
+// xmlEntry maps to the <entry> element attributes per RFC 3195 §7 DTD.
+// Also used for element name detection via XMLName.
+type xmlEntry struct {
+	XMLName    xml.Name `xml:""`
+	Facility   string   `xml:"facility,attr"`
+	Severity   string   `xml:"severity,attr"`
+	Timestamp  string   `xml:"timestamp,attr"`
+	Tag        string   `xml:"tag,attr"`
+	DeviceFQDN string   `xml:"deviceFQDN,attr"`
+	DeviceIP   string   `xml:"deviceIP,attr"`
+	PathID     string   `xml:"pathID,attr"`
+	Content    string   `xml:",chardata"`
+}
+
+// processPayload parses the XML payload from a BEEP frame.
+func (p *cookedParser) processPayload(payload []byte) {
+	if len(payload) == 0 {
+		return
+	}
+
+	var entry xmlEntry
+	if err := xml.Unmarshal(payload, &entry); err != nil {
+		p.emit(&syslog.Result{
+			Error: fmt.Errorf("rfc3195 cooked: invalid XML: %w", err),
+		})
+		return
+	}
+
+	switch entry.XMLName.Local {
+	case "entry":
+		p.processEntry(entry)
+	case "iam", "path", "ok":
+		if p.rawEmit != nil {
+			p.rawEmit(entry.XMLName.Local, payload)
+		}
+	default:
+		// Unknown elements silently skipped
+	}
+}
+
+// processEntry converts a parsed xmlEntry into a CookedMessage.
+func (p *cookedParser) processEntry(entry xmlEntry) {
+	msg := &CookedMessage{}
+
+	// facility (required, 0-23)
+	fac, err := strconv.Atoi(entry.Facility)
+	if err != nil || fac < 0 || fac > 23 {
+		p.emitError(fmt.Errorf("rfc3195 cooked: invalid facility %q", entry.Facility), msg)
+		return
+	}
+	facU8 := uint8(fac)
+	msg.Facility = &facU8
+
+	// severity (required, 0-7)
+	sev, err := strconv.Atoi(entry.Severity)
+	if err != nil || sev < 0 || sev > 7 {
+		p.emitError(fmt.Errorf("rfc3195 cooked: invalid severity %q", entry.Severity), msg)
+		return
+	}
+	sevU8 := uint8(sev)
+	msg.Severity = &sevU8
+
+	// priority = facility * 8 + severity
+	msg.ComputeFromPriority(facU8*8 + sevU8)
+	// ComputeFromPriority overwrites Facility/Severity, but they're the same values
+
+	// timestamp (optional)
+	if entry.Timestamp != "" {
+		t, err := time.Parse(time.Stamp, entry.Timestamp)
+		if err != nil {
+			p.emitError(fmt.Errorf("rfc3195 cooked: invalid timestamp %q: %w", entry.Timestamp, err), msg)
+			return
+		}
+		msg.Timestamp = &t
+	}
+
+	// tag → Appname
+	if entry.Tag != "" {
+		msg.Appname = &entry.Tag
+	}
+
+	// hostname derived from deviceFQDN (preferred) or deviceIP (fallback)
+	if entry.DeviceFQDN != "" {
+		msg.Hostname = &entry.DeviceFQDN
+		msg.DeviceFQDN = &entry.DeviceFQDN
+	}
+	if entry.DeviceIP != "" {
+		msg.DeviceIP = &entry.DeviceIP
+		if msg.Hostname == nil {
+			msg.Hostname = &entry.DeviceIP
+		}
+	}
+
+	// pathID
+	if entry.PathID != "" {
+		msg.PathID = &entry.PathID
+	}
+
+	// message content
+	if entry.Content != "" {
+		msg.Message = &entry.Content
+	}
+
+	p.emit(&syslog.Result{Message: msg})
+}
+
+// emitError emits a parse error, optionally including the partial message
+// in best-effort mode.
+func (p *cookedParser) emitError(err error, partial *CookedMessage) {
+	if p.bestEffort {
+		p.emit(&syslog.Result{Message: partial, Error: err})
+	} else {
+		p.emit(&syslog.Result{Error: err})
+	}
+}

--- a/rfc3195/cooked.go
+++ b/rfc3195/cooked.go
@@ -174,8 +174,6 @@ func (p *cookedParser) processEntry(entry xmlEntry) {
 		p.emitError(fmt.Errorf("rfc3195 cooked: invalid facility %q", entry.Facility), msg)
 		return
 	}
-	facU8 := uint8(fac)
-	msg.Facility = &facU8
 
 	// severity (required)
 	// DTD: %SEVERITY = DIGIT (0-9). Accept 0-9 per DTD.
@@ -184,12 +182,9 @@ func (p *cookedParser) processEntry(entry xmlEntry) {
 		p.emitError(fmt.Errorf("rfc3195 cooked: invalid severity %q", entry.Severity), msg)
 		return
 	}
-	sevU8 := uint8(sev)
-	msg.Severity = &sevU8
 
-	// priority = facility * 8 + severity
-	msg.ComputeFromPriority(facU8*8 + sevU8)
-	// ComputeFromPriority overwrites Facility/Severity, but they're the same values
+	// ComputeFromPriority sets Priority, Facility, and Severity in one call.
+	msg.ComputeFromPriority(uint8(fac)*8 + uint8(sev))
 
 	// timestamp (optional)
 	if entry.Timestamp != "" {

--- a/rfc3195/cooked.go
+++ b/rfc3195/cooked.go
@@ -122,8 +122,14 @@ func (p *cookedParser) Parse(r io.Reader) {
 	}
 }
 
+// xmlElement is a lightweight struct for element name detection.
+// Metadata elements (<iam>, <path>, <ok/>) are forwarded as raw bytes
+// and never need attribute parsing, so we avoid the cost of a full unmarshal.
+type xmlElement struct {
+	XMLName xml.Name `xml:""`
+}
+
 // xmlEntry maps to the <entry> element attributes per RFC 3195 §7 DTD.
-// Also used for element name detection via XMLName.
 type xmlEntry struct {
 	XMLName    xml.Name `xml:""`
 	Facility   string   `xml:"facility,attr"`
@@ -137,25 +143,32 @@ type xmlEntry struct {
 }
 
 // processPayload parses the XML payload from a BEEP frame.
+// For <entry> elements it performs a full unmarshal to extract attributes.
+// For metadata elements (<iam>, <path>, <ok/>) it only reads the element
+// name and forwards the raw bytes — no attribute parsing needed.
 func (p *cookedParser) processPayload(payload []byte) {
 	if len(payload) == 0 {
 		return
 	}
 
-	var entry xmlEntry
-	if err := xml.Unmarshal(payload, &entry); err != nil {
+	// Detect element name with a lightweight unmarshal (no attributes populated).
+	var elem xmlElement
+	if err := xml.Unmarshal(payload, &elem); err != nil {
 		p.emit(&syslog.Result{
 			Error: fmt.Errorf("rfc3195 cooked: invalid XML: %w", err),
 		})
 		return
 	}
 
-	switch entry.XMLName.Local {
+	switch elem.XMLName.Local {
 	case "entry":
+		var entry xmlEntry
+		// Well-formedness was validated above; this extracts attributes.
+		xml.Unmarshal(payload, &entry) //nolint:errcheck
 		p.processEntry(entry)
 	case "iam", "path", "ok":
 		if p.rawEmit != nil {
-			p.rawEmit(entry.XMLName.Local, payload)
+			p.rawEmit(elem.XMLName.Local, payload)
 		}
 	default:
 		// Unknown elements silently skipped

--- a/rfc3195/cooked.go
+++ b/rfc3195/cooked.go
@@ -221,8 +221,18 @@ func (p *cookedParser) processEntry(entry xmlEntry) {
 		return
 	}
 
-	// ComputeFromPriority sets Priority, Facility, and Severity in one call.
-	msg.ComputeFromPriority(uint8(fac)*8 + uint8(sev))
+	// Set Facility and Severity directly — the DTD allows values beyond
+	// the standard syslog priority range (facility 0-23, severity 0-7).
+	// ComputeFromPriority takes uint8, so fac*8+sev would overflow for
+	// facility > 31. Only set Priority when the values encode without loss.
+	facU8 := uint8(fac)
+	sevU8 := uint8(sev)
+	msg.Facility = &facU8
+	msg.Severity = &sevU8
+	if fac <= 23 && sev <= 7 {
+		pri := facU8*8 + sevU8
+		msg.Priority = &pri
+	}
 
 	// timestamp (optional)
 	if entry.Timestamp != "" {

--- a/rfc3195/cooked.go
+++ b/rfc3195/cooked.go
@@ -144,17 +144,13 @@ func (p *cookedParser) Parse(r io.Reader) {
 	}
 }
 
-// xmlElement is a lightweight struct for element name detection.
-// Metadata elements (<iam>, <path>, <ok/>) are forwarded as raw bytes
-// and never need attribute parsing, so we avoid the cost of a full unmarshal.
-type xmlElement struct {
-	XMLName xml.Name `xml:""`
-}
-
 // xmlEntry maps to the <entry> element attributes per RFC 3195 §7 DTD.
 // The xml:lang attribute defined in the DTD is intentionally not captured:
 // encoding/xml silently ignores unmapped attributes, and language tagging
 // is not part of the syslog.Message contract.
+//
+// Also used for element name detection via XMLName — metadata elements
+// (<iam>, <path>, <ok/>) populate only XMLName and are forwarded as raw bytes.
 type xmlEntry struct {
 	XMLName    xml.Name `xml:""`
 	Facility   string   `xml:"facility,attr"`
@@ -168,32 +164,25 @@ type xmlEntry struct {
 }
 
 // processPayload parses the XML payload from a BEEP frame.
-// For <entry> elements it performs a full unmarshal to extract attributes.
-// For metadata elements (<iam>, <path>, <ok/>) it only reads the element
-// name and forwards the raw bytes — no attribute parsing needed.
 func (p *cookedParser) processPayload(payload []byte) {
 	if len(payload) == 0 {
 		return
 	}
 
-	// Detect element name with a lightweight unmarshal (no attributes populated).
-	var elem xmlElement
-	if err := xml.Unmarshal(payload, &elem); err != nil {
+	var entry xmlEntry
+	if err := xml.Unmarshal(payload, &entry); err != nil {
 		p.emit(&syslog.Result{
 			Error: fmt.Errorf("rfc3195 cooked: invalid XML: %w", err),
 		})
 		return
 	}
 
-	switch elem.XMLName.Local {
+	switch entry.XMLName.Local {
 	case "entry":
-		var entry xmlEntry
-		// Well-formedness was validated above; this extracts attributes.
-		xml.Unmarshal(payload, &entry) //nolint:errcheck
 		p.processEntry(entry)
 	case "iam", "path", "ok":
 		if p.rawEmit != nil {
-			p.rawEmit(elem.XMLName.Local, payload)
+			p.rawEmit(entry.XMLName.Local, payload)
 		}
 	default:
 		// Unknown elements silently skipped

--- a/rfc3195/cooked.go
+++ b/rfc3195/cooked.go
@@ -34,12 +34,34 @@ func WithRawElementListener(f RawElementListener) syslog.ParserOption {
 	}
 }
 
+// WithCookedYear returns a parser option that sets the year for parsed
+// timestamps. RFC 3164 timestamps (used in COOKED <entry> elements) do
+// not include a year; without this option the year defaults to 0.
+func WithCookedYear(year int) syslog.ParserOption {
+	return func(p syslog.Parser) syslog.Parser {
+		p.(*cookedParser).year = year
+		return p
+	}
+}
+
+// WithCookedTimezone returns a parser option that sets the timezone for
+// parsed timestamps. When set, timestamps are interpreted in the given
+// location instead of UTC.
+func WithCookedTimezone(loc *time.Location) syslog.ParserOption {
+	return func(p syslog.Parser) syslog.Parser {
+		p.(*cookedParser).timezone = loc
+		return p
+	}
+}
+
 // cookedParser implements syslog.Parser for the RFC 3195 COOKED profile.
 type cookedParser struct {
 	bestEffort       bool
 	maxMessageLength int
 	emit             syslog.ParserListener
 	rawEmit          RawElementListener
+	year             int
+	timezone         *time.Location
 }
 
 // NewCookedParser returns a syslog.Parser for the RFC 3195 COOKED profile.
@@ -201,10 +223,19 @@ func (p *cookedParser) processEntry(entry xmlEntry) {
 
 	// timestamp (optional)
 	if entry.Timestamp != "" {
-		t, err := time.Parse(time.Stamp, entry.Timestamp)
+		var t time.Time
+		var err error
+		if p.timezone != nil {
+			t, err = time.ParseInLocation(time.Stamp, entry.Timestamp, p.timezone)
+		} else {
+			t, err = time.Parse(time.Stamp, entry.Timestamp)
+		}
 		if err != nil {
 			p.emitError(fmt.Errorf("rfc3195 cooked: invalid timestamp %q: %w", entry.Timestamp, err), msg)
 			return
+		}
+		if p.year > 0 {
+			t = t.AddDate(p.year, 0, 0)
 		}
 		msg.Timestamp = &t
 	}

--- a/rfc3195/cooked_message.go
+++ b/rfc3195/cooked_message.go
@@ -7,6 +7,12 @@ import syslog "github.com/leodido/go-syslog/v4"
 //
 // It extends syslog.Base with device identity fields (DeviceFQDN,
 // DeviceIP) and a PathID that links the entry to a relay path element.
+//
+// The RFC 3195 DTD allows facility 0–255 and severity 0–9, which extends
+// beyond the standard syslog priority range (facility 0–23, severity 0–7).
+// For extended-range values, Priority is nil and Valid() returns false even
+// though the message was successfully parsed. Use Facility/Severity directly
+// instead of Valid() to check parse success.
 type CookedMessage struct {
 	syslog.Base
 

--- a/rfc3195/cooked_message.go
+++ b/rfc3195/cooked_message.go
@@ -1,0 +1,19 @@
+package rfc3195
+
+import syslog "github.com/leodido/go-syslog/v4"
+
+// CookedMessage represents a syslog message parsed from an RFC 3195
+// COOKED profile <entry> element.
+//
+// It extends syslog.Base with device identity fields (DeviceFQDN,
+// DeviceIP) and a PathID that links the entry to a relay path element.
+type CookedMessage struct {
+	syslog.Base
+
+	DeviceFQDN *string
+	DeviceIP   *string
+	PathID     *string
+}
+
+// compile-time interface check
+var _ syslog.Message = (*CookedMessage)(nil)

--- a/rfc3195/cooked_test.go
+++ b/rfc3195/cooked_test.go
@@ -829,6 +829,50 @@ func TestCookedParser_WithCookedYearAndTimezone(t *testing.T) {
 	assert.Equal(t, "Europe/Rome", msg.Timestamp.Location().String())
 }
 
+func TestCookedParser_WithCookedYear_NegativeIgnored(t *testing.T) {
+	entry := `<entry facility='4' severity='2' timestamp='Jan  2 15:04:05'>neg year</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	var results []*syslog.Result
+	p := NewCookedParser(
+		WithCookedYear(-1),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	require.NotNil(t, msg.Timestamp)
+	assert.Equal(t, 0, msg.Timestamp.Year(), "negative year should be ignored")
+}
+
+func TestCookedParser_WithCookedYear_ZeroIgnored(t *testing.T) {
+	entry := `<entry facility='4' severity='2' timestamp='Jan  2 15:04:05'>zero year</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	var results []*syslog.Result
+	p := NewCookedParser(
+		WithCookedYear(0),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	require.NotNil(t, msg.Timestamp)
+	assert.Equal(t, 0, msg.Timestamp.Year(), "zero year should be ignored")
+}
+
 func TestCookedParser_TimestampDefaultYear0(t *testing.T) {
 	// Without WithCookedYear, year defaults to 0
 	entry := `<entry facility='4' severity='2' timestamp='Jan  2 15:04:05'>no year</entry>`

--- a/rfc3195/cooked_test.go
+++ b/rfc3195/cooked_test.go
@@ -649,6 +649,45 @@ func TestCookedParser_RPYFrameSkipped(t *testing.T) {
 	assert.NoError(t, results[0].Error)
 }
 
+func TestCookedParser_XmlLangIgnored(t *testing.T) {
+	// xml:lang is defined in the DTD but intentionally not captured.
+	// Verify it doesn't interfere with parsing.
+	entry := `<entry facility='4' severity='2' xml:lang='en'>with lang</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	assert.Equal(t, "with lang", *msg.Message)
+}
+
+func TestCookedParser_XMLEscapedContent(t *testing.T) {
+	// Verify XML character references are decoded in message content
+	entry := `<entry facility='4' severity='2'>1 &lt; 2 &amp; 3 &gt; 0</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	assert.Equal(t, "1 < 2 & 3 > 0", *msg.Message)
+}
+
 func TestCookedParser_WithCookedYear(t *testing.T) {
 	entry := `<entry facility='4' severity='2' timestamp='Jan  2 15:04:05'>with year</entry>`
 	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +

--- a/rfc3195/cooked_test.go
+++ b/rfc3195/cooked_test.go
@@ -3,6 +3,7 @@ package rfc3195
 import (
 	"strings"
 	"testing"
+	"time"
 
 	syslog "github.com/leodido/go-syslog/v4"
 	"github.com/stretchr/testify/assert"
@@ -646,6 +647,103 @@ func TestCookedParser_RPYFrameSkipped(t *testing.T) {
 
 	require.Len(t, results, 1)
 	assert.NoError(t, results[0].Error)
+}
+
+func TestCookedParser_WithCookedYear(t *testing.T) {
+	entry := `<entry facility='4' severity='2' timestamp='Jan  2 15:04:05'>with year</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	var results []*syslog.Result
+	p := NewCookedParser(
+		WithCookedYear(2025),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	require.NotNil(t, msg.Timestamp)
+	assert.Equal(t, 2025, msg.Timestamp.Year())
+	assert.Equal(t, time.January, msg.Timestamp.Month())
+	assert.Equal(t, 2, msg.Timestamp.Day())
+}
+
+func TestCookedParser_WithCookedTimezone(t *testing.T) {
+	entry := `<entry facility='4' severity='2' timestamp='Jan  2 15:04:05'>with tz</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	var results []*syslog.Result
+	p := NewCookedParser(
+		WithCookedTimezone(loc),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	require.NotNil(t, msg.Timestamp)
+	assert.Equal(t, "America/New_York", msg.Timestamp.Location().String())
+}
+
+func TestCookedParser_WithCookedYearAndTimezone(t *testing.T) {
+	entry := `<entry facility='4' severity='2' timestamp='Mar 15 10:30:00'>both</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	loc, err := time.LoadLocation("Europe/Rome")
+	require.NoError(t, err)
+
+	var results []*syslog.Result
+	p := NewCookedParser(
+		WithCookedYear(2024),
+		WithCookedTimezone(loc),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	require.NotNil(t, msg.Timestamp)
+	assert.Equal(t, 2024, msg.Timestamp.Year())
+	assert.Equal(t, time.March, msg.Timestamp.Month())
+	assert.Equal(t, "Europe/Rome", msg.Timestamp.Location().String())
+}
+
+func TestCookedParser_TimestampDefaultYear0(t *testing.T) {
+	// Without WithCookedYear, year defaults to 0
+	entry := `<entry facility='4' severity='2' timestamp='Jan  2 15:04:05'>no year</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	require.NotNil(t, msg.Timestamp)
+	assert.Equal(t, 0, msg.Timestamp.Year())
 }
 
 // Compile-time interface check

--- a/rfc3195/cooked_test.go
+++ b/rfc3195/cooked_test.go
@@ -144,7 +144,7 @@ func TestCookedParser_MultipleEntries(t *testing.T) {
 }
 
 func TestCookedParser_PriorityComputation(t *testing.T) {
-	// facility=23, severity=7 → priority = 23*8+7 = 191
+	// facility=23, severity=7 → priority = 23*8+7 = 191 (standard syslog max)
 	entry := `<entry facility='23' severity='7'>test</entry>`
 	input := cookedInput(entry)
 
@@ -164,8 +164,26 @@ func TestCookedParser_PriorityComputation(t *testing.T) {
 
 // Invalid attribute values
 
-func TestCookedParser_InvalidFacility_OutOfRange(t *testing.T) {
+func TestCookedParser_Facility24_Accepted(t *testing.T) {
+	// RFC 3195 §4.4.2 example uses facility='24' — DTD allows 1*3DIGIT
 	entry := `<entry facility='24' severity='0'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	assert.Equal(t, uint8(24), *msg.Facility)
+}
+
+func TestCookedParser_InvalidFacility_OutOfRange(t *testing.T) {
+	entry := `<entry facility='256' severity='0'>test</entry>`
 	input := cookedInput(entry)
 
 	var results []*syslog.Result
@@ -195,8 +213,29 @@ func TestCookedParser_InvalidFacility_NonNumeric(t *testing.T) {
 	assert.ErrorContains(t, results[0].Error, "invalid facility")
 }
 
+func TestCookedParser_Severity9_Accepted(t *testing.T) {
+	// DTD: %SEVERITY = DIGIT (0-9). Value 9 is accepted by the parser
+	// even though RFC 3164 only defines 0-7.
+	entry := `<entry facility='0' severity='9'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	// Priority = 0*8+9 = 9. ComputeFromPriority recomputes facility/severity
+	// from priority using standard syslog math (fac=9/8=1, sev=9%8=1).
+	msg := results[0].Message.(*CookedMessage)
+	assert.Equal(t, uint8(9), *msg.Priority)
+}
+
 func TestCookedParser_InvalidSeverity_OutOfRange(t *testing.T) {
-	entry := `<entry facility='0' severity='8'>test</entry>`
+	entry := `<entry facility='0' severity='10'>test</entry>`
 	input := cookedInput(entry)
 
 	var results []*syslog.Result
@@ -476,7 +515,7 @@ func TestCookedParser_EmptyStream(t *testing.T) {
 // Best effort mode
 
 func TestCookedParser_BestEffort_InvalidFacility(t *testing.T) {
-	entry := `<entry facility='99' severity='0'>test</entry>`
+	entry := `<entry facility='999' severity='0'>test</entry>`
 	input := cookedInput(entry)
 
 	var results []*syslog.Result

--- a/rfc3195/cooked_test.go
+++ b/rfc3195/cooked_test.go
@@ -1,0 +1,613 @@
+package rfc3195
+
+import (
+	"strings"
+	"testing"
+
+	syslog "github.com/leodido/go-syslog/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Full <entry> with all attributes
+const fullEntry = `<entry facility='4' severity='2' timestamp='Oct 11 22:14:15' tag='su' deviceFQDN='mymachine.example.com' deviceIP='10.0.0.1' pathID='173'>'su root' failed for lonvick on /dev/pts/8</entry>`
+
+// Minimal <entry> with only required attributes
+const minimalEntry = `<entry facility='0' severity='0'></entry>`
+
+func cookedInput(payloads ...string) string {
+	var b strings.Builder
+	seq := 0
+	for i, p := range payloads {
+		b.WriteString(beepFrame("ANS", 1, 0, '.', seq, i, p))
+		seq += len(p)
+	}
+	b.WriteString(beepFrame("NUL", 1, 0, '.', seq, -1, ""))
+	return b.String()
+}
+
+func TestCookedParser_FullEntry(t *testing.T) {
+	input := cookedInput(fullEntry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	require.NotNil(t, results[0].Message)
+
+	msg := results[0].Message.(*CookedMessage)
+	assert.True(t, msg.Valid())
+
+	// Priority = 4*8 + 2 = 34
+	assert.Equal(t, uint8(34), *msg.Priority)
+	assert.Equal(t, uint8(4), *msg.Facility)
+	assert.Equal(t, uint8(2), *msg.Severity)
+
+	assert.Equal(t, "su", *msg.Appname)
+	assert.Equal(t, "mymachine.example.com", *msg.Hostname)
+	assert.Equal(t, "mymachine.example.com", *msg.DeviceFQDN)
+	assert.Equal(t, "10.0.0.1", *msg.DeviceIP)
+	assert.Equal(t, "173", *msg.PathID)
+	assert.Equal(t, "'su root' failed for lonvick on /dev/pts/8", *msg.Message)
+
+	require.NotNil(t, msg.Timestamp)
+	assert.Equal(t, 10, int(msg.Timestamp.Month()))
+	assert.Equal(t, 11, msg.Timestamp.Day())
+	assert.Equal(t, 22, msg.Timestamp.Hour())
+	assert.Equal(t, 14, msg.Timestamp.Minute())
+	assert.Equal(t, 15, msg.Timestamp.Second())
+}
+
+func TestCookedParser_MinimalEntry(t *testing.T) {
+	input := cookedInput(minimalEntry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+
+	msg := results[0].Message.(*CookedMessage)
+	assert.True(t, msg.Valid())
+	assert.Equal(t, uint8(0), *msg.Priority)
+	assert.Equal(t, uint8(0), *msg.Facility)
+	assert.Equal(t, uint8(0), *msg.Severity)
+	assert.Nil(t, msg.Timestamp)
+	assert.Nil(t, msg.Appname)
+	assert.Nil(t, msg.Hostname)
+	assert.Nil(t, msg.DeviceFQDN)
+	assert.Nil(t, msg.DeviceIP)
+	assert.Nil(t, msg.PathID)
+	assert.Nil(t, msg.Message)
+}
+
+func TestCookedParser_HostnameFromDeviceIP(t *testing.T) {
+	// No deviceFQDN, only deviceIP — hostname should come from deviceIP
+	entry := `<entry facility='1' severity='3' deviceIP='192.168.1.1'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	msg := results[0].Message.(*CookedMessage)
+	assert.Equal(t, "192.168.1.1", *msg.Hostname)
+	assert.Nil(t, msg.DeviceFQDN)
+	assert.Equal(t, "192.168.1.1", *msg.DeviceIP)
+}
+
+func TestCookedParser_HostnameFromDeviceFQDN_Preferred(t *testing.T) {
+	// Both deviceFQDN and deviceIP — hostname should come from deviceFQDN
+	entry := `<entry facility='1' severity='3' deviceFQDN='host.example.com' deviceIP='10.0.0.1'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	msg := results[0].Message.(*CookedMessage)
+	assert.Equal(t, "host.example.com", *msg.Hostname)
+}
+
+func TestCookedParser_MultipleEntries(t *testing.T) {
+	e1 := `<entry facility='0' severity='0'>msg1</entry>`
+	e2 := `<entry facility='1' severity='1'>msg2</entry>`
+	input := cookedInput(e1, e2)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 2)
+	assert.Equal(t, "msg1", *results[0].Message.(*CookedMessage).Message)
+	assert.Equal(t, "msg2", *results[1].Message.(*CookedMessage).Message)
+}
+
+func TestCookedParser_PriorityComputation(t *testing.T) {
+	// facility=23, severity=7 → priority = 23*8+7 = 191
+	entry := `<entry facility='23' severity='7'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	msg := results[0].Message.(*CookedMessage)
+	assert.Equal(t, uint8(191), *msg.Priority)
+	assert.Equal(t, uint8(23), *msg.Facility)
+	assert.Equal(t, uint8(7), *msg.Severity)
+}
+
+// Invalid attribute values
+
+func TestCookedParser_InvalidFacility_OutOfRange(t *testing.T) {
+	entry := `<entry facility='24' severity='0'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.ErrorContains(t, results[0].Error, "invalid facility")
+	assert.Nil(t, results[0].Message)
+}
+
+func TestCookedParser_InvalidFacility_NonNumeric(t *testing.T) {
+	entry := `<entry facility='abc' severity='0'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.ErrorContains(t, results[0].Error, "invalid facility")
+}
+
+func TestCookedParser_InvalidSeverity_OutOfRange(t *testing.T) {
+	entry := `<entry facility='0' severity='8'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.ErrorContains(t, results[0].Error, "invalid severity")
+	assert.Nil(t, results[0].Message)
+}
+
+func TestCookedParser_InvalidSeverity_NonNumeric(t *testing.T) {
+	entry := `<entry facility='0' severity='xyz'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.ErrorContains(t, results[0].Error, "invalid severity")
+}
+
+func TestCookedParser_InvalidTimestamp(t *testing.T) {
+	entry := `<entry facility='0' severity='0' timestamp='not-a-timestamp'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.ErrorContains(t, results[0].Error, "invalid timestamp")
+	assert.Nil(t, results[0].Message)
+}
+
+func TestCookedParser_InvalidXML(t *testing.T) {
+	entry := `<entry facility='0' severity='0'>unclosed`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.ErrorContains(t, results[0].Error, "invalid XML")
+}
+
+// Metadata elements
+
+func TestCookedParser_RawElementListener_IAM(t *testing.T) {
+	iam := `<iam fqdn='collector.example.com' ip='10.0.0.99' type='collector'>Located in rack 5</iam>`
+	input := cookedInput(iam)
+
+	var rawCalls []struct {
+		name string
+		xml  []byte
+	}
+	p := NewCookedParser(
+		syslog.WithListener(func(r *syslog.Result) {}),
+		WithRawElementListener(func(name string, raw []byte) {
+			rawCalls = append(rawCalls, struct {
+				name string
+				xml  []byte
+			}{name, raw})
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, rawCalls, 1)
+	assert.Equal(t, "iam", rawCalls[0].name)
+	assert.Equal(t, []byte(iam), rawCalls[0].xml)
+}
+
+func TestCookedParser_RawElementListener_Path(t *testing.T) {
+	path := `<path fromFQDN='relay.example.com' fromIP='10.0.0.50' toFQDN='collector.example.com' toIP='10.0.0.99' pathID='173' linkprops='ULRI'></path>`
+	input := cookedInput(path)
+
+	var rawCalls []struct {
+		name string
+		xml  []byte
+	}
+	p := NewCookedParser(
+		syslog.WithListener(func(r *syslog.Result) {}),
+		WithRawElementListener(func(name string, raw []byte) {
+			rawCalls = append(rawCalls, struct {
+				name string
+				xml  []byte
+			}{name, raw})
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, rawCalls, 1)
+	assert.Equal(t, "path", rawCalls[0].name)
+}
+
+func TestCookedParser_RawElementListener_OK(t *testing.T) {
+	ok := `<ok></ok>`
+	input := cookedInput(ok)
+
+	var rawCalls []struct {
+		name string
+		xml  []byte
+	}
+	p := NewCookedParser(
+		syslog.WithListener(func(r *syslog.Result) {}),
+		WithRawElementListener(func(name string, raw []byte) {
+			rawCalls = append(rawCalls, struct {
+				name string
+				xml  []byte
+			}{name, raw})
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, rawCalls, 1)
+	assert.Equal(t, "ok", rawCalls[0].name)
+}
+
+func TestCookedParser_MetadataSkippedWithoutListener(t *testing.T) {
+	iam := `<iam fqdn='c.example.com' ip='10.0.0.99' type='collector'/>`
+	entry := `<entry facility='0' severity='0'>test</entry>`
+	input := cookedInput(iam, entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	// Only the entry should be emitted, iam silently skipped
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	assert.Equal(t, "test", *results[0].Message.(*CookedMessage).Message)
+}
+
+func TestCookedParser_UnknownElementSkipped(t *testing.T) {
+	unknown := `<foobar attr='val'>content</foobar>`
+	entry := `<entry facility='0' severity='0'>test</entry>`
+	input := cookedInput(unknown, entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "test", *results[0].Message.(*CookedMessage).Message)
+}
+
+// Frame handling
+
+func TestCookedParser_ERRFrame(t *testing.T) {
+	entry := `<entry facility='0' severity='0'>msg1</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		"ERR 1 0 . " + "0 12\r\nserver errorEND\r\n"
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 2)
+	assert.NoError(t, results[0].Error)
+	assert.ErrorContains(t, results[1].Error, "ERR frame")
+}
+
+func TestCookedParser_NULTerminates(t *testing.T) {
+	entry := `<entry facility='0' severity='0'>msg1</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "") +
+		beepFrame("ANS", 1, 0, '.', 0, 1, entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+}
+
+func TestCookedParser_SEQSkipped(t *testing.T) {
+	entry := `<entry facility='0' severity='0'>test</entry>`
+	input := seqFrame(0, 0, 4096) +
+		beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		seqFrame(1, len(entry), 4096) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+}
+
+func TestCookedParser_EOFWithoutNUL(t *testing.T) {
+	entry := `<entry facility='0' severity='0'>test</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+}
+
+func TestCookedParser_FrameScanError(t *testing.T) {
+	input := "INVALID\r\n"
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.ErrorContains(t, results[0].Error, "frame scan error")
+}
+
+func TestCookedParser_EmptyPayload(t *testing.T) {
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, "") +
+		beepFrame("NUL", 1, 0, '.', 0, -1, "")
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	assert.Len(t, results, 0)
+}
+
+func TestCookedParser_EmptyStream(t *testing.T) {
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(""))
+
+	assert.Len(t, results, 0)
+}
+
+// Best effort mode
+
+func TestCookedParser_BestEffort_InvalidFacility(t *testing.T) {
+	entry := `<entry facility='99' severity='0'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(
+		syslog.WithBestEffort(),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+	assert.NotNil(t, results[0].Message) // partial message emitted in best-effort
+}
+
+func TestCookedParser_BestEffort_InvalidXML(t *testing.T) {
+	entry := `<entry facility='0' severity='0'>unclosed`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(
+		syslog.WithBestEffort(),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+}
+
+func TestCookedParser_HasBestEffort(t *testing.T) {
+	p := NewCookedParser()
+	assert.False(t, p.HasBestEffort())
+
+	p2 := NewCookedParser(syslog.WithBestEffort())
+	assert.True(t, p2.HasBestEffort())
+}
+
+func TestCookedParser_MaxMessageLength(t *testing.T) {
+	entry := `<entry facility='0' severity='0'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(
+		syslog.WithMaxMessageLength(5), // too small for the XML
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.Error(t, results[0].Error)
+}
+
+func TestCookedParser_DefaultListener(t *testing.T) {
+	entry := `<entry facility='0' severity='0'>test</entry>`
+	input := cookedInput(entry)
+
+	p := NewCookedParser()
+	assert.NotPanics(t, func() {
+		p.Parse(strings.NewReader(input))
+	})
+}
+
+func TestCookedParser_WithMachineOptions(t *testing.T) {
+	// WithMachineOptions is a no-op for COOKED (no inner machine),
+	// but should not panic
+	entry := `<entry facility='0' severity='0'>test</entry>`
+	input := cookedInput(entry)
+
+	noopOpt := func(m syslog.Machine) syslog.Machine { return m }
+
+	var results []*syslog.Result
+	p := NewCookedParser(
+		syslog.WithMachineOptions(noopOpt),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, r)
+		}),
+	)
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+}
+
+func TestCookedParser_MSGFrame(t *testing.T) {
+	// COOKED profile uses MSG frames (not just ANS) per RFC 3195 §4.3
+	entry := `<entry facility='0' severity='0'>via MSG</entry>`
+	input := "MSG 1 0 . 0 " + strings.Repeat("", 0) +
+		beepFrame("MSG", 1, 0, '.', 0, -1, entry)[4:] // reuse beepFrame but it's MSG
+
+	// Actually let's build it properly
+	input = beepFrame("MSG", 1, 0, '.', 0, -1, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.Equal(t, "via MSG", *results[0].Message.(*CookedMessage).Message)
+}
+
+func TestCookedParser_RPYFrameSkipped(t *testing.T) {
+	// RPY frames should be skipped (they carry <ok/> responses in full BEEP)
+	entry := `<entry facility='0' severity='0'>test</entry>`
+	input := "RPY 0 0 . 0 2\r\nokEND\r\n" +
+		beepFrame("ANS", 1, 0, '.', 0, 0, entry) +
+		beepFrame("NUL", 1, 0, '.', len(entry), -1, "")
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+}
+
+// Compile-time interface check
+var _ syslog.Parser = (*cookedParser)(nil)

--- a/rfc3195/cooked_test.go
+++ b/rfc3195/cooked_test.go
@@ -163,6 +163,32 @@ func TestCookedParser_PriorityComputation(t *testing.T) {
 	assert.Equal(t, uint8(7), *msg.Severity)
 }
 
+func TestCookedParser_PriorityRoundTrip(t *testing.T) {
+	// Verify Priority, Facility, and Severity are consistent for a
+	// standard-range value: priority = facility*8 + severity, and
+	// facility = priority/8, severity = priority%8.
+	entry := `<entry facility='4' severity='2'>round-trip</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	require.NotNil(t, msg.Priority)
+	assert.Equal(t, uint8(34), *msg.Priority)                        // 4*8 + 2
+	assert.Equal(t, uint8(4), *msg.Facility)                         // 34 / 8
+	assert.Equal(t, uint8(2), *msg.Severity)                         // 34 % 8
+	assert.Equal(t, *msg.Facility*8+*msg.Severity, *msg.Priority)    // round-trip
+	assert.Equal(t, *msg.Priority/8, *msg.Facility)                  // decompose back
+	assert.Equal(t, *msg.Priority%8, *msg.Severity)                  // decompose back
+}
+
 // Invalid attribute values
 
 func TestCookedParser_Facility24_Accepted(t *testing.T) {

--- a/rfc3195/cooked_test.go
+++ b/rfc3195/cooked_test.go
@@ -166,7 +166,8 @@ func TestCookedParser_PriorityComputation(t *testing.T) {
 // Invalid attribute values
 
 func TestCookedParser_Facility24_Accepted(t *testing.T) {
-	// RFC 3195 §4.4.2 example uses facility='24' — DTD allows 1*3DIGIT
+	// RFC 3195 §4.4.2 example uses facility='24' — DTD allows 1*3DIGIT.
+	// facility > 23 is outside the standard priority range, so Priority is nil.
 	entry := `<entry facility='24' severity='0'>test</entry>`
 	input := cookedInput(entry)
 
@@ -181,6 +182,69 @@ func TestCookedParser_Facility24_Accepted(t *testing.T) {
 	assert.NoError(t, results[0].Error)
 	msg := results[0].Message.(*CookedMessage)
 	assert.Equal(t, uint8(24), *msg.Facility)
+	assert.Equal(t, uint8(0), *msg.Severity)
+	assert.Nil(t, msg.Priority, "facility > 23 cannot encode as uint8 priority")
+}
+
+func TestCookedParser_Facility80_NoOverflow(t *testing.T) {
+	// facility=80 would overflow uint8 in fac*8+sev (80*8=640).
+	// Verify Facility/Severity are set correctly and Priority is nil.
+	entry := `<entry facility='80' severity='3'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	assert.Equal(t, uint8(80), *msg.Facility)
+	assert.Equal(t, uint8(3), *msg.Severity)
+	assert.Nil(t, msg.Priority, "facility > 31 would overflow uint8 priority")
+}
+
+func TestCookedParser_Facility255_NoOverflow(t *testing.T) {
+	// Max DTD facility value — must not corrupt fields.
+	entry := `<entry facility='255' severity='9'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	assert.Equal(t, uint8(255), *msg.Facility)
+	assert.Equal(t, uint8(9), *msg.Severity)
+	assert.Nil(t, msg.Priority, "extended range cannot encode as uint8 priority")
+}
+
+func TestCookedParser_Severity8_NoPriority(t *testing.T) {
+	// severity=8 is valid per DTD but outside standard 0-7 range.
+	entry := `<entry facility='4' severity='8'>test</entry>`
+	input := cookedInput(entry)
+
+	var results []*syslog.Result
+	p := NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, r)
+	}))
+
+	p.Parse(strings.NewReader(input))
+
+	require.Len(t, results, 1)
+	assert.NoError(t, results[0].Error)
+	msg := results[0].Message.(*CookedMessage)
+	assert.Equal(t, uint8(4), *msg.Facility)
+	assert.Equal(t, uint8(8), *msg.Severity)
+	assert.Nil(t, msg.Priority, "severity > 7 cannot encode as standard priority")
 }
 
 func TestCookedParser_InvalidFacility_OutOfRange(t *testing.T) {
@@ -229,10 +293,10 @@ func TestCookedParser_Severity9_Accepted(t *testing.T) {
 
 	require.Len(t, results, 1)
 	assert.NoError(t, results[0].Error)
-	// Priority = 0*8+9 = 9. ComputeFromPriority recomputes facility/severity
-	// from priority using standard syslog math (fac=9/8=1, sev=9%8=1).
 	msg := results[0].Message.(*CookedMessage)
-	assert.Equal(t, uint8(9), *msg.Priority)
+	assert.Equal(t, uint8(0), *msg.Facility)
+	assert.Equal(t, uint8(9), *msg.Severity)
+	assert.Nil(t, msg.Priority, "severity > 7 is outside standard priority range")
 }
 
 func TestCookedParser_InvalidSeverity_OutOfRange(t *testing.T) {

--- a/rfc3195/raw_test.go
+++ b/rfc3195/raw_test.go
@@ -1,7 +1,6 @@
 package rfc3195
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -10,22 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// beepFrame builds a raw BEEP data frame string.
-// Size is computed automatically from len(payload).
-// For ANS frames, pass ansno >= 0. For other types, ansno is ignored.
-func beepFrame(keyword string, channel, msgno int, more byte, seqno int, ansno int, payload string) string {
-	size := len(payload)
-	header := fmt.Sprintf("%s %d %d %c %d %d", keyword, channel, msgno, more, seqno, size)
-	if keyword == "ANS" {
-		header += " " + strconv.Itoa(ansno)
-	}
-	return header + "\r\n" + payload + "END\r\n"
-}
-
-func seqFrame(channel, ackno, window int) string {
-	return fmt.Sprintf("SEQ %d %d %d\r\n", channel, ackno, window)
-}
 
 // A minimal valid RFC 5424 message
 const validRFC5424 = "<1>1 - - - - - -"

--- a/rfc3195/testutil_test.go
+++ b/rfc3195/testutil_test.go
@@ -1,0 +1,22 @@
+package rfc3195
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// beepFrame builds a raw BEEP data frame string.
+// Size is computed automatically from len(payload).
+// For ANS frames, pass ansno >= 0. For other types, ansno is ignored.
+func beepFrame(keyword string, channel, msgno int, more byte, seqno int, ansno int, payload string) string {
+	size := len(payload)
+	header := fmt.Sprintf("%s %d %d %c %d %d", keyword, channel, msgno, more, seqno, size)
+	if keyword == "ANS" {
+		header += " " + strconv.Itoa(ansno)
+	}
+	return header + "\r\n" + payload + "END\r\n"
+}
+
+func seqFrame(channel, ackno, window int) string {
+	return fmt.Sprintf("SEQ %d %d %d\r\n", channel, ackno, window)
+}


### PR DESCRIPTION
Adds the COOKED profile parser to `rfc3195/`, completing RFC 3195 support. PR 2 of 2 for #31.

No changes to `syslog.go` or existing packages.

## Commits

### `feat(rfc3195): add CookedMessage struct`

`CookedMessage` embeds `syslog.Base` and adds three fields from the `<entry>` DTD that have no equivalent in `syslog.Base`:
- `DeviceFQDN` — originating device FQDN
- `DeviceIP` — originating device IP
- `PathID` — links entry to a relay path element

### `feat(rfc3195): add COOKED profile parser`

Implements `syslog.Parser` for the RFC 3195 COOKED profile. Parses `<entry>` XML elements from BEEP frame payloads into `CookedMessage`.

**Attribute value parsing** (no Ragel needed — values are simple):
- `facility` → `strconv.Atoi` + range 0–255 (per DTD `1*3DIGIT`)
- `severity` → `strconv.Atoi` + range 0–9 (per DTD `DIGIT`)
- `priority` → set only when fac ≤ 23 and sev ≤ 7 (standard syslog range that fits uint8)
- `timestamp` → `time.Parse(time.Stamp, ...)` (optional, same format rfc3164 uses)
- `tag` → `Base.Appname`
- `Base.Hostname` → derived from `deviceFQDN` (preferred) or `deviceIP` (fallback)

**Session metadata** (`<iam>`, `<path>`, `<ok/>`):
- Optional `WithRawElementListener(func(elementName string, rawXML []byte))` forwards raw XML bytes
- go-syslog does not define Go types for these — a future go-beep library can unmarshal them
- Without the listener, metadata elements are silently skipped

### `refactor(rfc3195): extract shared test helpers to testutil_test.go`

Moves `beepFrame` and `seqFrame` helpers out of `raw_test.go` into `testutil_test.go` so both RAW and COOKED tests can use them.

### `fix(rfc3195): widen facility/severity range per DTD`

DTD defines `%FACILITY = 1*3DIGIT` (0–255) and `%SEVERITY = DIGIT` (0–9). The initial implementation used RFC 3164's narrower 0–23 / 0–7 ranges.

### `fix(rfc3195): remove redundant facility/severity assignments`

`ComputeFromPriority` already sets `Priority`, `Facility`, and `Severity`. Removed the manual assignments that were immediately overwritten.

### `fix(rfc3195): lightweight element name detection for metadata`

Uses a minimal `xmlElement` struct (just `XMLName`) for initial element name detection. Only performs the full `xmlEntry` unmarshal for `<entry>` elements.

### `feat(rfc3195): add WithCookedYear and WithCookedTimezone options`

RFC 3164 timestamps lack year and timezone. `WithCookedYear` sets the year via `time.Date`; `WithCookedTimezone` uses `ParseInLocation` for timezone-aware parsing.

### `fix(rfc3195): document xml:lang omission, add xml:lang and XML escape tests`

Documents that `xml:lang` (defined in the DTD) is intentionally not captured. Adds tests verifying `xml:lang` doesn't interfere with parsing and that XML character references (`&lt;` `&amp;` `&gt;`) are decoded correctly.

### `fix(rfc3195): prevent uint8 overflow in priority computation`

`ComputeFromPriority(uint8(fac)*8 + uint8(sev))` silently overflows for facility > 31. Set `Facility` and `Severity` directly from parsed values. Only set `Priority` when fac ≤ 23 and sev ≤ 7 (the standard range where `fac*8+sev` fits in uint8 and round-trips correctly).

### `fix(rfc3195): use time.Date instead of AddDate for year assignment`

`AddDate(year, 0, 0)` adds N years to year 0, which coincidentally produces the right result but has wrong semantics. `time.Date(year, ...)` explicitly sets the year.

### `fix(rfc3195): revert to single unmarshal, remove xmlElement`

The lightweight `xmlElement` optimization double-unmarshalled `<entry>` elements (the common case) to save work on rare metadata elements. Revert to single unmarshal into `xmlEntry`, route on `XMLName.Local`, forward raw bytes for non-entry elements. Also removes the `//nolint:errcheck` the double unmarshal required.

### `fix(rfc3195): WithCookedYear ignores non-positive values`

`WithCookedYear(-1)` and `WithCookedYear(0)` were silently stored but had no effect. Validate at option time: values ≤ 0 are ignored.

### `docs(rfc3195): document Valid() behavior for extended-range values, add priority round-trip test`

`CookedMessage` doc comment now notes that `Valid()` returns false for extended-range facility/severity values (`Priority` is nil). Added `TestCookedParser_PriorityRoundTrip` with explicit assertions that `priority = facility*8 + severity` round-trips correctly.

## Design decisions

- **No inner syslog.Machine**: `<entry>` has pre-decomposed fields as XML attributes. No need to reconstruct a syslog line and re-parse it.
- **No Ragel**: Attribute values are integers (`strconv.Atoi`) or a stdlib time format (`time.Stamp`). XML parsing via `encoding/xml` dominates the cost.
- **Single unmarshal**: `processPayload` unmarshals once into `xmlEntry` (which includes `XMLName` for element routing). Metadata elements only use `XMLName`; the extra attribute fields are harmlessly zero-valued.
- **Raw XML for metadata**: Keeps go-syslog out of BEEP session types while avoiding the re-parse cost for a future go-beep.
- **Priority only for standard range**: DTD allows facility 0–255 and severity 0–9, but `ComputeFromPriority` takes uint8. Priority is only set when fac ≤ 23 and sev ≤ 7 to avoid silent overflow corruption. `Valid()` returns false for extended-range entries — documented on `CookedMessage`.
- **`xml:lang` not captured**: The DTD defines it but `encoding/xml` silently ignores unmapped attributes. Language tagging is not part of the `syslog.Message` contract.

## Coverage

100% statement coverage, 46 COOKED tests (120 total in `rfc3195/`).

Refs: #31