### PR TITLE
docs: add rfc3195 documentation, fix incomplete godoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To wrap up, this package provides:
 
 - an [RFC5424-compliant parser and builder](/rfc5424)
 - an [RFC3164-compliant parser](/rfc3164) - ie., BSD-syslog messages
+- an [RFC3195 parser](/rfc3195) for syslog over [BEEP](https://datatracker.ietf.org/doc/html/rfc3195) (RAW and COOKED profiles)
 - a parser that works on streams for syslog with [octet counting](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.1) framing technique, see [octetcounting](/octetcounting)
 - a parser that works on streams for syslog with [non-transparent](https://tools.ietf.org/html/rfc6587#section-3.4.2) framing technique, see [nontransparent](/nontransparent)
 
@@ -196,6 +197,19 @@ Things we do not support:
 - trailers other than `LF` or `NUL`
 - trailers which length is greater than 1 byte
 - trailer change on a frame-by-frame basis
+
+### RFC 3195 (BEEP)
+
+[RFC 3195](https://datatracker.ietf.org/doc/html/rfc3195) defines syslog transport over the [BEEP](https://datatracker.ietf.org/doc/html/rfc3080) protocol. It specifies two profiles:
+
+- **RAW** (§4.2): syslog messages are carried as CRLF-terminated payloads in BEEP ANS frames. The inner messages can be either RFC 5424 or RFC 3164 format.
+- **COOKED** (§4.3): syslog data is encoded as XML `<entry>` elements with attributes for facility, severity, timestamp, tag, and device identity.
+
+The [rfc3195 package](./rfc3195) provides parsers for both profiles. It implements BEEP frame scanning (MSG, RPY, ERR, ANS, NUL, SEQ frames) and extracts syslog messages from the frame payloads.
+
+This is a parsing-only implementation — it does not handle BEEP session management, channel negotiation, or TLS. Feed it a stream of BEEP frames and it will emit parsed syslog messages.
+
+To quickly understand how to use it please have a look at the [example file](./rfc3195/example_test.go).
 
 ## Performances
 

--- a/common/doc.go
+++ b/common/doc.go
@@ -1,0 +1,4 @@
+// Package common provides shared constants and utility functions used across
+// the syslog parser packages, including facility/severity mappings and
+// priority validation.
+package common

--- a/nontransparent/doc.go
+++ b/nontransparent/doc.go
@@ -1,0 +1,4 @@
+// Package nontransparent provides a stream parser for syslog messages framed
+// with the non-transparent technique described in RFC 6587 §3.4.2. Messages
+// are delimited by a trailer byte, either LF (default) or NUL.
+package nontransparent

--- a/nontransparent/parser.go
+++ b/nontransparent/parser.go
@@ -257,7 +257,9 @@ func (m *machine) HasBestEffort() bool {
 // WithMaxMessageLength does nothing for this parser.
 func (m *machine) WithMaxMessageLength(length int) {}
 
-// WithTrailer ... todo(leodido)
+// WithTrailer sets the trailer byte used to delimit syslog messages in
+// non-transparent framing. Supported values are LF (line feed, default)
+// and NUL (null byte). See RFC 6587 §3.4.2.
 func WithTrailer(t TrailerType) syslog.ParserOption {
 	return func(m syslog.Parser) syslog.Parser {
 		if val, err := t.Value(); err == nil {

--- a/nontransparent/parser.go.rl
+++ b/nontransparent/parser.go.rl
@@ -153,7 +153,9 @@ func (m *machine) HasBestEffort() bool {
 // WithMaxMessageLength does nothing for this parser.
 func (m *machine) WithMaxMessageLength(length int) {}
 
-// WithTrailer ... todo(leodido)
+// WithTrailer sets the trailer byte used to delimit syslog messages in
+// non-transparent framing. Supported values are LF (line feed, default)
+// and NUL (null byte). See RFC 6587 §3.4.2.
 func WithTrailer(t TrailerType) syslog.ParserOption {
     return func(m syslog.Parser) syslog.Parser {
         if val, err := t.Value(); err == nil {

--- a/octetcounting/doc.go
+++ b/octetcounting/doc.go
@@ -1,0 +1,4 @@
+// Package octetcounting provides a stream parser for syslog messages framed
+// with the octet counting technique described in RFC 5425 §4.3 and RFC 6587
+// §3.4.1. Each message is prefixed with its length in bytes.
+package octetcounting

--- a/rfc3164/doc.go
+++ b/rfc3164/doc.go
@@ -1,0 +1,5 @@
+// Package rfc3164 provides a parser for RFC 3164 (BSD syslog) messages.
+// The parser is implemented as a Ragel finite-state machine and supports
+// extensions for Cisco IOS syslog formats, RFC 3339 timestamps, and
+// configurable timezone/year handling.
+package rfc3164

--- a/rfc3195/doc.go
+++ b/rfc3195/doc.go
@@ -1,0 +1,8 @@
+// Package rfc3195 provides parsers for RFC 3195 syslog transport over BEEP
+// (RFC 3080). It supports both the RAW profile (§4.2), which carries syslog
+// messages in ANS frame payloads, and the COOKED profile (§4.3), which
+// encodes syslog data as XML <entry> elements.
+//
+// This is a parsing-only implementation. It does not handle BEEP session
+// management, channel negotiation, or TLS.
+package rfc3195

--- a/rfc3195/example_test.go
+++ b/rfc3195/example_test.go
@@ -1,0 +1,233 @@
+package rfc3195_test
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	syslog "github.com/leodido/go-syslog/v4"
+	"github.com/leodido/go-syslog/v4/rfc3195"
+)
+
+func init() {
+	spew.Config.DisableCapacities = true
+	spew.Config.DisablePointerAddresses = true
+}
+
+func output(out interface{}) {
+	spew.Dump(out)
+}
+
+// beepFrame builds a raw BEEP data frame string for use in examples.
+func beepFrame(keyword string, channel, msgno int, more byte, seqno int, ansno int, payload string) string {
+	size := len(payload)
+	header := fmt.Sprintf("%s %d %d %c %d %d", keyword, channel, msgno, more, seqno, size)
+	if keyword == "ANS" {
+		header += " " + fmt.Sprintf("%d", ansno)
+	}
+	return header + "\r\n" + payload + "END\r\n"
+}
+
+// Example_raw demonstrates parsing RFC 3195 RAW profile frames containing
+// RFC 5424 syslog messages. Each ANS frame carries one syslog message
+// terminated by CRLF. A NUL frame signals end of exchange.
+func Example_raw() {
+	payload := "<165>4 2018-10-11T22:14:15.003Z mymach.it e - 1 [ex@32473 iut=\"3\"] An application event log entry...\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
+
+	var results []syslog.Result
+	p := rfc3195.NewParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, *r)
+	}))
+	p.Parse(strings.NewReader(input))
+	output(results)
+	// Output:
+	// ([]syslog.Result) (len=1) {
+	//  (syslog.Result) {
+	//   Message: (*rfc5424.SyslogMessage)({
+	//    Base: (syslog.Base) {
+	//     Facility: (*uint8)(20),
+	//     Severity: (*uint8)(5),
+	//     Priority: (*uint8)(165),
+	//     MessageCounter: (*uint32)(<nil>),
+	//     Sequence: (*uint32)(<nil>),
+	//     Timestamp: (*time.Time)(2018-10-11 22:14:15.003 +0000 UTC),
+	//     Hostname: (*string)((len=9) "mymach.it"),
+	//     Appname: (*string)((len=1) "e"),
+	//     ProcID: (*string)(<nil>),
+	//     MsgID: (*string)((len=1) "1"),
+	//     Message: (*string)((len=33) "An application event log entry...")
+	//    },
+	//    Version: (uint16) 4,
+	//    StructuredData: (*map[string]map[string]string)((len=1) {
+	//     (string) (len=8) "ex@32473": (map[string]string) (len=1) {
+	//      (string) (len=3) "iut": (string) (len=1) "3"
+	//     }
+	//    })
+	//   }),
+	//   Error: (error) <nil>
+	//  }
+	// }
+}
+
+// Example_rawRFC3164 demonstrates parsing RFC 3195 RAW profile frames
+// containing RFC 3164 (BSD syslog) messages.
+func Example_rawRFC3164() {
+	payload := "<34>Oct 11 22:14:15 mymachine su: 'su root' failed\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
+
+	var results []syslog.Result
+	p := rfc3195.NewParserRFC3164(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, *r)
+	}))
+	p.Parse(strings.NewReader(input))
+	output(results)
+	// Output:
+	// ([]syslog.Result) (len=1) {
+	//  (syslog.Result) {
+	//   Message: (*rfc3164.SyslogMessage)({
+	//    Base: (syslog.Base) {
+	//     Facility: (*uint8)(4),
+	//     Severity: (*uint8)(2),
+	//     Priority: (*uint8)(34),
+	//     MessageCounter: (*uint32)(<nil>),
+	//     Sequence: (*uint32)(<nil>),
+	//     Timestamp: (*time.Time)(0000-10-11 22:14:15 +0000 UTC),
+	//     Hostname: (*string)((len=9) "mymachine"),
+	//     Appname: (*string)((len=2) "su"),
+	//     ProcID: (*string)(<nil>),
+	//     MsgID: (*string)(<nil>),
+	//     Message: (*string)((len=16) "'su root' failed")
+	//    }
+	//   }),
+	//   Error: (error) <nil>
+	//  }
+	// }
+}
+
+// Example_cooked demonstrates parsing RFC 3195 COOKED profile frames.
+// The COOKED profile carries syslog data as XML <entry> elements with
+// attributes for facility, severity, timestamp, tag, and device identity.
+func Example_cooked() {
+	xmlPayload := `<entry facility='4' severity='2' timestamp='Oct 11 22:14:15' tag='su' deviceFQDN='mymachine.example.com'>'su root' failed for lonvick on /dev/pts/8</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, xmlPayload) +
+		beepFrame("NUL", 1, 0, '.', len(xmlPayload), -1, "")
+
+	var results []syslog.Result
+	p := rfc3195.NewCookedParser(syslog.WithListener(func(r *syslog.Result) {
+		results = append(results, *r)
+	}))
+	p.Parse(strings.NewReader(input))
+	output(results)
+	// Output:
+	// ([]syslog.Result) (len=1) {
+	//  (syslog.Result) {
+	//   Message: (*rfc3195.CookedMessage)({
+	//    Base: (syslog.Base) {
+	//     Facility: (*uint8)(4),
+	//     Severity: (*uint8)(2),
+	//     Priority: (*uint8)(34),
+	//     MessageCounter: (*uint32)(<nil>),
+	//     Sequence: (*uint32)(<nil>),
+	//     Timestamp: (*time.Time)(0000-10-11 22:14:15 +0000 UTC),
+	//     Hostname: (*string)((len=21) "mymachine.example.com"),
+	//     Appname: (*string)((len=2) "su"),
+	//     ProcID: (*string)(<nil>),
+	//     MsgID: (*string)(<nil>),
+	//     Message: (*string)((len=42) "'su root' failed for lonvick on /dev/pts/8")
+	//    },
+	//    DeviceFQDN: (*string)((len=21) "mymachine.example.com"),
+	//    DeviceIP: (*string)(<nil>),
+	//    PathID: (*string)(<nil>)
+	//   }),
+	//   Error: (error) <nil>
+	//  }
+	// }
+}
+
+// Example_cookedWithOptions demonstrates the COOKED profile with year and
+// timezone options. RFC 3164 timestamps lack a year; WithCookedYear sets it.
+// WithCookedTimezone interprets timestamps in the given location.
+func Example_cookedWithOptions() {
+	est, _ := time.LoadLocation("EST")
+	xmlPayload := `<entry facility='4' severity='2' timestamp='Oct 11 22:14:15' tag='su' deviceFQDN='mymachine.example.com'>'su root' failed</entry>`
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, xmlPayload) +
+		beepFrame("NUL", 1, 0, '.', len(xmlPayload), -1, "")
+
+	var results []syslog.Result
+	p := rfc3195.NewCookedParser(
+		rfc3195.WithCookedYear(2025),
+		rfc3195.WithCookedTimezone(est),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, *r)
+		}),
+	)
+	p.Parse(strings.NewReader(input))
+	output(results)
+	// Output:
+	// ([]syslog.Result) (len=1) {
+	//  (syslog.Result) {
+	//   Message: (*rfc3195.CookedMessage)({
+	//    Base: (syslog.Base) {
+	//     Facility: (*uint8)(4),
+	//     Severity: (*uint8)(2),
+	//     Priority: (*uint8)(34),
+	//     MessageCounter: (*uint32)(<nil>),
+	//     Sequence: (*uint32)(<nil>),
+	//     Timestamp: (*time.Time)(2025-10-11 22:14:15 -0500 EST),
+	//     Hostname: (*string)((len=21) "mymachine.example.com"),
+	//     Appname: (*string)((len=2) "su"),
+	//     ProcID: (*string)(<nil>),
+	//     MsgID: (*string)(<nil>),
+	//     Message: (*string)((len=16) "'su root' failed")
+	//    },
+	//    DeviceFQDN: (*string)((len=21) "mymachine.example.com"),
+	//    DeviceIP: (*string)(<nil>),
+	//    PathID: (*string)(<nil>)
+	//   }),
+	//   Error: (error) <nil>
+	//  }
+	// }
+}
+
+// Example_rawBestEffort demonstrates best-effort parsing in the RAW profile.
+// When the syslog message is malformed, best-effort mode returns whatever
+// was successfully parsed along with the error.
+func Example_rawBestEffort() {
+	payload := "<1>1 A - - - - - -\r\n"
+	input := beepFrame("ANS", 1, 0, '.', 0, 0, payload) +
+		beepFrame("NUL", 1, 0, '.', len(payload), -1, "")
+
+	var results []syslog.Result
+	p := rfc3195.NewParser(
+		syslog.WithBestEffort(),
+		syslog.WithListener(func(r *syslog.Result) {
+			results = append(results, *r)
+		}),
+	)
+	p.Parse(strings.NewReader(input))
+	output(results[0].Message)
+	fmt.Println(results[0].Error)
+	// Output:
+	// (*rfc5424.SyslogMessage)({
+	//  Base: (syslog.Base) {
+	//   Facility: (*uint8)(0),
+	//   Severity: (*uint8)(1),
+	//   Priority: (*uint8)(1),
+	//   MessageCounter: (*uint32)(<nil>),
+	//   Sequence: (*uint32)(<nil>),
+	//   Timestamp: (*time.Time)(<nil>),
+	//   Hostname: (*string)(<nil>),
+	//   Appname: (*string)(<nil>),
+	//   ProcID: (*string)(<nil>),
+	//   MsgID: (*string)(<nil>),
+	//   Message: (*string)(<nil>)
+	//  },
+	//  Version: (uint16) 1,
+	//  StructuredData: (*map[string]map[string]string)(<nil>)
+	// })
+	// expecting a RFC3339MICRO timestamp or a nil value [col 5]
+}

--- a/rfc5424/doc.go
+++ b/rfc5424/doc.go
@@ -1,0 +1,4 @@
+// Package rfc5424 provides a parser and builder for RFC 5424 (IETF syslog)
+// messages. The parser is implemented as a Ragel finite-state machine for
+// performance. The builder constructs valid RFC 5424 messages programmatically.
+package rfc5424

--- a/syslog.go
+++ b/syslog.go
@@ -112,7 +112,8 @@ func (m *Base) FacilityMessage() *string {
 	return nil
 }
 
-// FacilityLevel returns the
+// FacilityLevel returns the keyword level for the current facility value (e.g., "kern", "user", "mail").
+// Falls back to the facility message if no keyword is defined.
 func (m *Base) FacilityLevel() *string {
 	if m.Facility != nil {
 		if msg, ok := common.FacilityKeywords[*m.Facility]; ok {


### PR DESCRIPTION
## Description

Documentation patchset to catch up with what's already built on `develop`. The `rfc3195/` package (BEEP frame scanner + RAW and COOKED profile parsers, ~2,500 lines) had zero documentation. Several other packages had incomplete or placeholder godoc comments.

**Changes:**

- **README.md**: Add `rfc3195/` to the package list and a dedicated "RFC 3195 (BEEP)" section under "Message transfer", following the same structure as the octetcounting and nontransparent sections
- **rfc3195/example_test.go**: 5 testable examples for godoc — RAW profile (RFC 5424), RAW profile (RFC 3164), COOKED profile, COOKED with year/timezone options, and best-effort mode
- **doc.go** for 6 packages: `rfc3195/`, `rfc5424/`, `rfc3164/`, `octetcounting/`, `nontransparent/`, `common/` — each now has a package-level comment visible in `go doc`
- **syslog.go**: Complete the truncated `FacilityLevel` godoc comment
- **nontransparent/parser.go** + **parser.go.rl**: Replace `WithTrailer` placeholder (`// WithTrailer ... todo(leodido)`) with a proper doc comment

## Related Issue(s)

No specific issue — this addresses documentation gaps identified during review of the rfc3195 package and existing codebase.

## How to test

```bash
# All tests (including new examples)
go test ./...

# rfc3195 examples specifically
go test ./rfc3195/ -run Example -v

# Verify godoc output
go doc github.com/leodido/go-syslog/v4/rfc3195
go doc github.com/leodido/go-syslog/v4/rfc5424
go doc github.com/leodido/go-syslog/v4/rfc3164
go doc github.com/leodido/go-syslog/v4/octetcounting
go doc github.com/leodido/go-syslog/v4/nontransparent
go doc github.com/leodido/go-syslog/v4/common
```