### PR TITLE
chore: drop Go 1.21, add Go 1.25 and 1.26 support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	},
 	"features": {
 		"ghcr.io/devcontainers/features/go": {
-			"version": "1.23"
+			"version": "1.26"
 		}
 	},
 	"customizations": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,21 +16,24 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         go: [
-          '1.21',
           '1.22',
           '1.23',
           '1.24',
+          '1.25',
+          '1.26',
         ]
         include:
           # Set the minimum Go patch version for the given Go minor
-          - go: '1.21'
-            GO_VERSION: '~1.21.0'
           - go: '1.22'
             GO_VERSION: '~1.22.0'
           - go: '1.23'
             GO_VERSION: '~1.23.0'
           - go: '1.24'
             GO_VERSION: '~1.24.0'
+          - go: '1.25'
+            GO_VERSION: '~1.25.0'
+          - go: '1.26'
+            GO_VERSION: '~1.26.0'
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -26,6 +26,8 @@ jobs:
             '1.22',
             '1.23',
             '1.24',
+            '1.25',
+            '1.26',
         ]
         include:
           # Set the minimum Go patch version for the given Go minor
@@ -35,6 +37,10 @@ jobs:
             GO_VERSION: '~1.23.0'
           - go: '1.24'
             GO_VERSION: '~1.24.0'
+          - go: '1.25'
+            GO_VERSION: '~1.25.0'
+          - go: '1.26'
+            GO_VERSION: '~1.26.0'
 
     steps:
       - name: Check out the source code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,21 +16,24 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         go: [
-          '1.21',
           '1.22',
           '1.23',
           '1.24',
+          '1.25',
+          '1.26',
         ]
         include:
           # Set the minimum Go patch version for the given Go minor
-          - go: '1.21'
-            GO_VERSION: '~1.21.0'
           - go: '1.22'
             GO_VERSION: '~1.22.0'
           - go: '1.23'
             GO_VERSION: '~1.23.0'
           - go: '1.24'
             GO_VERSION: '~1.24.0'
+          - go: '1.25'
+            GO_VERSION: '~1.25.0'
+          - go: '1.26'
+            GO_VERSION: '~1.26.0'
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/auto/machine.go
+++ b/auto/machine.go
@@ -14,7 +14,6 @@ import (
 func SafeMachineOptions(opts []syslog.MachineOption) []syslog.MachineOption {
 	safe := make([]syslog.MachineOption, len(opts))
 	for i, opt := range opts {
-		opt := opt // TODO: remove when dropping Go 1.21 (loop var scoping, go.dev/blog/loopvar-preview)
 		safe[i] = func(m syslog.Machine) (result syslog.Machine) {
 			defer func() {
 				if r := recover(); r != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/leodido/go-syslog/v4
 
-go 1.21
+go 1.22
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/nontransparent/parser_test.go
+++ b/nontransparent/parser_test.go
@@ -154,7 +154,6 @@ func init() {
 
 func TestParse(t *testing.T) {
 	for _, tc := range testCases {
-		tc := tc
 
 		// Test with trailer LF
 		var inputWithLF = tc.input

--- a/octetcounting/performance_test.go
+++ b/octetcounting/performance_test.go
@@ -60,7 +60,6 @@ var benchCases = []benchCase{
 
 func BenchmarkParse(b *testing.B) {
 	for _, tc := range benchCases {
-		tc := tc
 		if tc.maxLength == 0 {
 			tc.maxLength = 8192
 		}
@@ -88,7 +87,6 @@ func BenchmarkParseAuto(b *testing.B) {
 	}
 
 	for _, tc := range cases {
-		tc := tc // TODO: remove when dropping Go 1.21 (loop var scoping, go.dev/blog/loopvar-preview)
 		b.Run("Auto/"+tc.label, func(b *testing.B) {
 			p := NewParserAuto(
 				syslog.WithListener(func(*syslog.Result) {}),

--- a/rfc3164/machine_test.go
+++ b/rfc3164/machine_test.go
@@ -541,7 +541,6 @@ var testCases = []testCase{
 
 func TestMachineParse(t *testing.T) {
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(syslogtesting.RightPad(string(tc.input), 50), func(t *testing.T) {
 			t.Parallel()
 

--- a/rfc5424/machine_test.go
+++ b/rfc5424/machine_test.go
@@ -1703,7 +1703,6 @@ func runTestCases(t *testing.T, tcs []testCase, machineOpts ...syslog.MachineOpt
 	t.Helper()
 
 	for _, tc := range tcs {
-		tc := tc
 
 		t.Run(syslogtesting.RightPad(string(tc.input), 50), func(t *testing.T) {
 			t.Parallel()

--- a/rfc5424/parser_test.go
+++ b/rfc5424/parser_test.go
@@ -20,7 +20,6 @@ func TestParserParse(t *testing.T) {
 	p := NewParser()
 	pBest := NewParser(WithBestEffort())
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(syslogtesting.RightPad(string(tc.input), 50), func(t *testing.T) {
 			t.Parallel()
 

--- a/rfc5424/performance_test.go
+++ b/rfc5424/performance_test.go
@@ -98,7 +98,6 @@ var benchCases = []benchCase{
 
 func BenchmarkParse(b *testing.B) {
 	for _, tc := range benchCases {
-		tc := tc
 		m := NewMachine(WithBestEffort())
 		b.Run(syslogtesting.RightPad(tc.label, 50), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -110,7 +109,6 @@ func BenchmarkParse(b *testing.B) {
 
 func BenchmarkParseCompliantMessage(b *testing.B) {
 	for _, tc := range benchCases {
-		tc := tc
 		m := NewMachine(WithBestEffort(), WithCompliantMsg())
 		b.Run(syslogtesting.RightPad(tc.label, 50), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {


### PR DESCRIPTION
## Description

Update Go version support to match the current ecosystem:

- **go.mod**: bump minimum from `go 1.21` to `go 1.22`
- **CI matrix** (build.yml, tests.yml): drop 1.21, add 1.25 and 1.26
- **Devcontainer**: update from Go 1.23 to 1.26 (latest stable)
- **Loop-variable captures**: remove all `opt := opt` / `tc := tc` captures across 7 files — no longer needed since Go 1.22 scopes loop variables per-iteration

Go's release policy supports the two most recent major releases (currently 1.25 and 1.26). The CI matrix covers 1.22–1.26 for broader compatibility.

## How to test

```bash
go build ./...
go test -race ./...
```