### PR TITLE
test(rfc3164): stabilize timezone example

### DIFF
--- a/rfc3164/example_test.go
+++ b/rfc3164/example_test.go
@@ -92,7 +92,7 @@ func Example_currentyear() {
 }
 
 func Example_withtimezone() {
-	cet, _ := time.LoadLocation("CET")
+	cet := time.FixedZone("CET", 60*60)
 	i := []byte(`<13>Jan 30 02:08:03 host app: Test`)
 	p := NewParser(WithTimezone(cet))
 	m, _ := p.Parse(i)


### PR DESCRIPTION
## Summary

- replace the named `CET` timezone database lookup in `Example_withtimezone` with a deterministic fixed-offset zone
- preserve the example's expected `+0100 CET` output without depending on historical timezone data
- keep parser behavior and public APIs unchanged

## Root cause

The example parses a year-zero RFC3164 timestamp. The timezone database resolves that historical date using local mean time, producing an offset such as `+0017 LMT` instead of the expected modern CET offset.

## Validation

- `go test ./rfc3164 -run '^Example_withtimezone$' -count=1 -v`
- `go test ./rfc3164 -count=1`
- `go test ./... -count=1`

The focused test was observed failing before the change with `02:25:33 +0017 LMT` and passing afterward with `03:08:03 +0100 CET`.
