### PR TITLE
feat(auto): detect priorityless syslog formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,11 @@ m := auto.NewMachine(
 )
 ```
 
-It also works with the stream parsers via `NewParserAuto` - see [octet counting](#octet-counting) and [non-transparent](#non-transparent) below.
+`NewParserAuto` also provides auto-detection to the stream parsers for
+PRI-bearing messages - see [octet counting](#octet-counting) and
+[non-transparent](#non-transparent) below. Stream framing still requires the
+syslog payload to begin with PRI, so priorityless auto-detection currently
+applies only when parsing directly with `auto.Machine`.
 
 Auto-detect chooses a format before parsing. Inputs beginning with `<` scan for
 the first `>` and then use the existing post-PRI VERSION-versus-timestamp

--- a/README.md
+++ b/README.md
@@ -193,9 +193,23 @@ m := auto.NewMachine(
 )
 ```
 
+To accept messages that omit PRI, enable the parser option for both inner
+formats. Strict PRI handling remains the default when these options are absent.
+
+```go
+m := auto.NewMachine(
+    auto.WithRFC3164Options(rfc3164.WithOptionalPriority()),
+    auto.WithRFC5424Options(rfc5424.WithOptionalPriority()),
+)
+```
+
 It also works with the stream parsers via `NewParserAuto` - see [octet counting](#octet-counting) and [non-transparent](#non-transparent) below.
 
-Performance-wise, auto-detect peeks at a few bytes after the PRI to pick the format - no allocations, no copying. It's as fast as calling the right parser yourself.
+Auto-detect chooses a format before parsing. Inputs beginning with `<` scan for
+the first `>` and then use the existing post-PRI VERSION-versus-timestamp
+heuristic. Inputs without PRI use narrow leading signatures: an RFC3164 month
+or four-digit RFC3339 year selects RFC3164, while other inputs default to
+RFC5424.
 
 ## Message transfer
 

--- a/auto/benchmark_test.go
+++ b/auto/benchmark_test.go
@@ -8,9 +8,11 @@ import (
 )
 
 var (
-	benchRFC5424 = []byte(`<165>4 2018-10-11T22:14:15.003Z mymach.it e - 1 [ex@32473 iut="3"] An application event log entry...`)
-	benchRFC3164 = []byte(`<13>Dec  2 16:31:03 host app: Test message for benchmarking`)
-	benchGarbage = []byte(`<34>1 not-a-valid-anything-at-all`)
+	benchRFC5424             = []byte(`<165>4 2018-10-11T22:14:15.003Z mymach.it e - 1 [ex@32473 iut="3"] An application event log entry...`)
+	benchRFC3164             = []byte(`<13>Dec  2 16:31:03 host app: Test message for benchmarking`)
+	benchPrioritylessRFC5424 = []byte(`1 2018-10-11T22:14:15.003Z mymach.it e - 1 - message`)
+	benchPrioritylessRFC3164 = []byte(`Dec  2 16:31:03 host app: Test message for benchmarking`)
+	benchGarbage             = []byte(`<34>1 not-a-valid-anything-at-all`)
 )
 
 // BenchmarkPeekOnly measures the peek detection function in isolation.
@@ -23,6 +25,18 @@ func BenchmarkPeekOnly_RFC5424(b *testing.B) {
 func BenchmarkPeekOnly_RFC3164(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		detect(benchRFC3164)
+	}
+}
+
+func BenchmarkPeekOnly_PrioritylessRFC5424(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		detect(benchPrioritylessRFC5424)
+	}
+}
+
+func BenchmarkPeekOnly_PrioritylessRFC3164(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		detect(benchPrioritylessRFC3164)
 	}
 }
 

--- a/auto/detect.go
+++ b/auto/detect.go
@@ -1,25 +1,20 @@
 package auto
 
-// detect inspects the bytes after the PRI closing bracket to determine
-// whether the input is RFC 5424 or RFC 3164. It returns the detected format.
-//
-// The function examines at most ~6 bytes and runs in O(1) time.
-// Decision table:
-//   - Letter, space, '*'     → RFC 3164 (month name, leading space, Cisco star)
-//   - '0'                    → RFC 3164 (zero-padded or Cisco counter)
-//   - 4+ digits              → RFC 3164 (year prefix / long Cisco counter)
-//   - 1-3 digits + space     → RFC 5424 (VERSION SP)
-//   - 1-3 digits + ':'       → RFC 3164 (Cisco counter)
-//   - Default                → RFC 5424
+// detect classifies input as RFC3164 or RFC5424 using narrow leading-byte
+// signatures. Inputs beginning with '<' retain the existing post-PRI heuristic;
+// inputs without PRI use timestamp or VERSION signatures.
 func detect(input []byte) Format {
+	if len(input) == 0 || input[0] != '<' {
+		return detectWithoutPRI(input)
+	}
+
 	// Find the closing '>' of PRI.
 	pos := 0
 	for pos < len(input) && input[pos] != '>' {
 		pos++
 	}
 	if pos >= len(input) {
-		// No '>' found — default to RFC 5424 (will fail with PRI error).
-		return FormatRFC5424
+		return detectWithoutPRI(input)
 	}
 
 	// Move past '>'.
@@ -71,4 +66,33 @@ func detect(input []byte) Format {
 
 	// Any other byte — default to RFC 5424 (stricter grammar gives clearer errors).
 	return FormatRFC5424
+}
+
+func detectWithoutPRI(input []byte) Format {
+	if hasRFC3164MonthPrefix(input) {
+		return FormatRFC3164
+	}
+	if len(input) >= 5 &&
+		input[0] >= '0' && input[0] <= '9' &&
+		input[1] >= '0' && input[1] <= '9' &&
+		input[2] >= '0' && input[2] <= '9' &&
+		input[3] >= '0' && input[3] <= '9' &&
+		input[4] == '-' {
+		return FormatRFC3164
+	}
+	return FormatRFC5424
+}
+
+func hasRFC3164MonthPrefix(input []byte) bool {
+	if len(input) < 4 || input[3] != ' ' {
+		return false
+	}
+
+	switch string(input[:3]) {
+	case "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+		"Jul", "Aug", "Sep", "Oct", "Nov", "Dec":
+		return true
+	default:
+		return false
+	}
 }

--- a/auto/detect_test.go
+++ b/auto/detect_test.go
@@ -110,7 +110,17 @@ func TestDetect_RFC3164_RFC3339Timestamp(t *testing.T) {
 }
 
 func TestDetect_NoPRI(t *testing.T) {
-	// No '>' found → default RFC 5424
+	months := []string{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
+	for _, month := range months {
+		t.Run(month, func(t *testing.T) {
+			input := fmt.Sprintf("%s  1 00:00:00 host app: msg", month)
+			assert.Equal(t, FormatRFC3164, detect([]byte(input)))
+		})
+	}
+
+	assert.Equal(t, FormatRFC3164, detect([]byte("2025-01-03T14:07:15Z host app: msg")))
+	assert.Equal(t, FormatRFC5424, detect([]byte("1 2025-01-03T14:07:15Z host app - - - msg")))
+	assert.Equal(t, FormatRFC5424, detect([]byte("1 2025-01-03T14:07:15Z host app - - - value > threshold")))
 	assert.Equal(t, FormatRFC5424, detect([]byte("no pri here")))
 	assert.Equal(t, FormatRFC5424, detect([]byte("")))
 	assert.Equal(t, FormatRFC5424, detect([]byte("<34")))

--- a/auto/detect_test.go
+++ b/auto/detect_test.go
@@ -126,6 +126,23 @@ func TestDetect_NoPRI(t *testing.T) {
 	assert.Equal(t, FormatRFC5424, detect([]byte("<34")))
 }
 
+func TestDetect_NoPRI_NearMissesDefaultToRFC5424(t *testing.T) {
+	tests := []string{
+		"Jax  1 00:00:00 host app: msg",
+		"JanX 1 00:00:00 host app: msg",
+		"oct 11 22:14:15 host app: msg",
+		"202-01-03T14:07:15Z host app: msg",
+		"20250-01-03T14:07:15Z host app: msg",
+		"2025/01/03 host app: msg",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			assert.Equal(t, FormatRFC5424, detect([]byte(input)))
+		})
+	}
+}
+
 func TestDetect_EmptyAfterPRI(t *testing.T) {
 	// Nothing after '>' → default RFC 5424
 	assert.Equal(t, FormatRFC5424, detect([]byte("<34>")))

--- a/auto/machine_test.go
+++ b/auto/machine_test.go
@@ -167,6 +167,57 @@ func TestParse_WithoutFallback_ValidMessage(t *testing.T) {
 	assert.Equal(t, FormatRFC5424, DetectFormat(msg))
 }
 
+func TestParse_WithoutFallback_PrioritylessRFC3164(t *testing.T) {
+	m := NewMachine(
+		WithoutFallback(),
+		WithRFC3164Options(rfc3164.WithOptionalPriority()),
+	)
+
+	msg, err := m.Parse([]byte("Oct 11 22:14:15 mymachine su: message"))
+
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	assert.Equal(t, FormatRFC3164, DetectFormat(msg))
+	sm, ok := msg.(*rfc3164.SyslogMessage)
+	require.True(t, ok)
+	assert.Nil(t, sm.Priority)
+}
+
+func TestParse_WithoutFallback_PrioritylessRFC3164RFC3339(t *testing.T) {
+	m := NewMachine(
+		WithoutFallback(),
+		WithRFC3164Options(
+			rfc3164.WithOptionalPriority(),
+			rfc3164.WithRFC3339(),
+		),
+	)
+
+	msg, err := m.Parse([]byte("2025-01-03T14:07:15Z host app: message"))
+
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	assert.Equal(t, FormatRFC3164, DetectFormat(msg))
+	sm, ok := msg.(*rfc3164.SyslogMessage)
+	require.True(t, ok)
+	assert.Nil(t, sm.Priority)
+}
+
+func TestParse_WithoutFallback_PrioritylessRFC5424(t *testing.T) {
+	m := NewMachine(
+		WithoutFallback(),
+		WithRFC5424Options(rfc5424.WithOptionalPriority()),
+	)
+
+	msg, err := m.Parse([]byte("1 2025-01-03T14:07:15Z host app - - - message"))
+
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	assert.Equal(t, FormatRFC5424, DetectFormat(msg))
+	sm, ok := msg.(*rfc5424.SyslogMessage)
+	require.True(t, ok)
+	assert.Nil(t, sm.Priority)
+}
+
 // --- Best-effort ---
 
 func TestParse_BestEffort_PartialResult_NoFallback(t *testing.T) {


### PR DESCRIPTION
## Summary

- route priorityless RFC3164 month and RFC3339 timestamp signatures to the RFC3164 parser
- keep VERSION-led and otherwise ambiguous priorityless input on the RFC5424 default
- stop treating unrelated `>` bytes in priorityless message bodies as PRI closure
- support priorityless RFC3164 and RFC5424 parsing with fallback disabled when their parser options are enabled
- document auto-detection configuration and routing rules

## Implementation

Inputs beginning with `<` retain the existing post-PRI detector unchanged. Inputs without PRI use bounded leading signatures: a valid RFC3164 month followed by space or a four-digit year followed by `-` selects RFC3164; everything else defaults to RFC5424.

The detector never scans a priorityless message body, so RFC5424 content such as `value > threshold` cannot influence format selection.

## Dependency

This PR is stacked on #64 and targets `leox/rfc5424-optional-priority`. After #64 merges, retarget this PR to `develop`.

## Validation

- behavioral RED captured before implementation for month/year routing, body `>`, and no-fallback RFC3164 parsing
- `go test ./auto -run '^(TestDetect.*|TestParse_WithoutFallback_Priorityless.*)$' -count=1`
- `go test ./auto -count=1`
- `go test ./... -count=1`
- `go test -race ./auto -count=1`
- `go test ./auto -run '^$' -bench '^BenchmarkPeekOnly_' -benchmem -count=3`
- `git diff --check 832bf2e10ead5d26dac7a1d5168545516c25ffe0...HEAD`

Implements the auto-detection portion of #60.
