### PR TITLE
docs: improve parser guidance and refresh benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ go get github.com/leodido/go-syslog/v4
 
 ## Docs
 
-[![Documentation](https://img.shields.io/badge/godoc-reference-blue.svg?style=for-the-badge)](http://godoc.org/github.com/leodido/go-syslog/v4)
+[![Documentation](https://img.shields.io/badge/godoc-reference-blue.svg?style=for-the-badge)](https://pkg.go.dev/github.com/leodido/go-syslog/v4)
 
 The [docs](docs/) directory contains `.dot` files representing the finite-state machines (FSMs) implementing the syslog parsers and transports.
 

--- a/README.md
+++ b/README.md
@@ -46,36 +46,17 @@ same interface; its options are demonstrated in
 [rfc3164/example_test.go](./rfc3164/example_test.go).
 
 ```go
-i := []byte(`<165>4 2018-10-11T22:14:15.003Z mymach.it e - 1 [ex@32473 iut="3"] An application event log entry...`)
+input := []byte(`<165>4 2018-10-11T22:14:15.003Z mymach.it e - 1 [ex@32473 iut="3"] An application event log entry...`)
 p := rfc5424.NewParser()
-m, e := p.Parse(i)
+msg, err := p.Parse(input)
+if err != nil {
+    log.Fatal(err)
+}
+
+m := msg.(*rfc5424.SyslogMessage)
+fmt.Println(*m.Priority, m.Version, *m.Hostname)
+// 165 4 mymach.it
 ```
-
-This results in `m` being equal to:
-
-```go
-// (*rfc5424.SyslogMessage)({
-//  Base: (syslog.Base) {
-//   Facility: (*uint8)(20),
-//   Severity: (*uint8)(5),
-//   Priority: (*uint8)(165),
-//   Timestamp: (*time.Time)(2018-10-11 22:14:15.003 +0000 UTC),
-//   Hostname: (*string)((len=9) "mymach.it"),
-//   Appname: (*string)((len=1) "e"),
-//   ProcID: (*string)(<nil>),
-//   MsgID: (*string)((len=1) "1"),
-//   Message: (*string)((len=33) "An application event log entry...")
-//  },
-//  Version: (uint16) 4,
-//  StructuredData: (*map[string]map[string]string)((len=1) {
-//   (string) (len=8) "ex@32473": (map[string]string) (len=1) {
-//    (string) (len=3) "iut": (string) (len=1) "3"
-//   }
-//  })
-// })
-```
-
-`e` is nil because the input is a valid RFC 5424 message.
 
 ### Messages without PRI
 
@@ -105,34 +86,18 @@ failure. An RFC 5424 partial result requires PRI and VERSION, or VERSION alone
 when `WithOptionalPriority()` is also set.
 
 ```go
-i := []byte("<1>1 A - - - - - -")
+input := []byte("<1>1 A - - - - - -")
 p := rfc5424.NewParser(rfc5424.WithBestEffort())
-m, e := p.Parse(i)
-```
+msg, err := p.Parse(input)
+partial := msg.(*rfc5424.SyslogMessage)
 
-```go
-// (*rfc5424.SyslogMessage)({
-//  Base: (syslog.Base) {
-//   Facility: (*uint8)(0),
-//   Severity: (*uint8)(1),
-//   Priority: (*uint8)(1),
-//   Timestamp: (*time.Time)(<nil>),
-//   Hostname: (*string)(<nil>),
-//   Appname: (*string)(<nil>),
-//   ProcID: (*string)(<nil>),
-//   MsgID: (*string)(<nil>),
-//   Message: (*string)(<nil>)
-//  },
-//  Version: (uint16) 1,
-//  StructuredData: (*map[string]map[string]string)(<nil>)
-// })
-```
-
-```go
+fmt.Println(*partial.Priority, partial.Version)
+fmt.Println(err)
+// 1 1
 // expecting a RFC3339MICRO timestamp or a nil value [col 5]
 ```
 
-Both `m` and `e` are non-nil because the parser collected a valid partial
+Both `msg` and `err` are non-nil because the parser collected a valid partial
 RFC 5424 message before the error.
 
 ### Builder
@@ -144,34 +109,16 @@ grammar.
 ```go
 msg := &rfc5424.SyslogMessage{}
 msg.SetTimestamp("invalid timestamp")
-msg.Valid() // Not yet a valid message (try msg.Valid())
+fmt.Println(msg.Timestamp == nil, msg.Valid())
+
 msg.SetPriority(191)
 msg.SetVersion(1)
-msg.Valid() // Now it is minimally valid
-```
+str, err := msg.String()
 
-The invalid timestamp is ignored, so `Timestamp` remains nil.
-
-```go
-// (*rfc5424.SyslogMessage)({
-//  Base: (syslog.Base) {
-//   Facility: (*uint8)(23),
-//   Severity: (*uint8)(7),
-//   Priority: (*uint8)(191),
-//   Timestamp: (*time.Time)(<nil>),
-//   Hostname: (*string)(<nil>),
-//   Appname: (*string)(<nil>),
-//   ProcID: (*string)(<nil>),
-//   MsgID: (*string)(<nil>),
-//   Message: (*string)(<nil>)
-//  },
-//  Version: (uint16) 1,
-//  StructuredData: (*map[string]map[string]string)(<nil>)
-// })
-```
-
-```go
-str, _ := msg.String()
+fmt.Println(msg.Valid(), err)
+fmt.Println(str)
+// true false
+// true <nil>
 // <191>1 - - - - - -
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)](LICENSE)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)](LICENSE)
 
 **Parsers for syslog messages and transports**
 
@@ -10,12 +10,12 @@ _This is the official continuation of influxdata/go-syslog_.
 
 This module includes:
 
-- an [RFC 5424-compliant parser and builder](/rfc5424)
-- an [RFC 3164-compliant parser](/rfc3164) for BSD syslog messages
-- an [auto-detect parser](/auto) that selects RFC 3164 or RFC 5424 per message
-- an [RFC 3195 parser](/rfc3195) for syslog over [BEEP](https://datatracker.ietf.org/doc/html/rfc3195), including RAW and COOKED profiles
-- an [octet-counting stream parser](/octetcounting) for [RFC 6587 transparent framing](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.1)
-- a [non-transparent stream parser](/nontransparent) for [RFC 6587 delimiter framing](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.2)
+- an [RFC 5424-compliant parser and builder](./rfc5424)
+- an [RFC 3164-compliant parser](./rfc3164) for BSD syslog messages
+- an [auto-detect parser](./auto) that selects RFC 3164 or RFC 5424 per message
+- an [RFC 3195 parser](./rfc3195) for syslog over [BEEP](https://datatracker.ietf.org/doc/html/rfc3195), including RAW and COOKED profiles
+- an [octet-counting stream parser](./octetcounting) for [RFC 6587 transparent framing](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.1)
+- a [non-transparent stream parser](./nontransparent) for [RFC 6587 delimiter framing](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.2)
 
 It can parse syslog messages received over:
 
@@ -124,7 +124,7 @@ fmt.Println(str)
 
 ### Auto-detect
 
-Use the [auto](/auto) package when a source mixes RFC 5424 and RFC 3164 messages.
+Use the [auto](./auto) package when a source mixes RFC 5424 and RFC 3164 messages.
 
 ```go
 m := auto.NewMachine()

--- a/README.md
+++ b/README.md
@@ -233,41 +233,37 @@ Run the benchmarks with:
 make bench
 ```
 
-The following results were measured on
-[this machine](#mymachine) while parsing RFC 5424 messages with best-effort mode
-enabled.
+The following `BenchmarkParse` results were measured on an Apple M4 Pro with
+14 logical CPUs, using Go 1.24.4 on `darwin/arm64`. Best-effort mode was enabled;
+`make bench` uses a five-second benchmark time.
 
 ```
-[no]_empty_input__________________________________-10  32072733   185.3 ns/op   272 B/op   4 allocs/op
-[no]_multiple_syslog_messages_on_multiple_lines___-10  27058381   219.8 ns/op   267 B/op   7 allocs/op
-[no]_impossible_timestamp_________________________-10   8732960   683.8 ns/op   555 B/op  12 allocs/op
-[no]_malformed_structured_data____________________-10  17997814   335.6 ns/op   499 B/op   8 allocs/op
-[no]_with_duplicated_structured_data_id___________-10   9254920   645.7 ns/op   672 B/op  15 allocs/op
-[ok]_minimal______________________________________-10  48347473   123.2 ns/op   227 B/op   5 allocs/op
-[ok]_average_message______________________________-10   6058492   986.8 ns/op  1344 B/op  20 allocs/op
-[ok]_complicated_message__________________________-10   7052536   843.2 ns/op  1232 B/op  23 allocs/op
-[ok]_very_long_message____________________________-10   2644068  2279.0 ns/op  2272 B/op  21 allocs/op
-[ok]_all_max_length_and_complete__________________-10   3611186  1675.0 ns/op  1848 B/op  27 allocs/op
-[ok]_all_max_length_except_structured_data_and_mes-10   5729514  1059.0 ns/op   851 B/op  12 allocs/op
-[ok]_minimal_with_message_containing_newline______-10  43165338   142.9 ns/op   230 B/op   6 allocs/op
-[ok]_w/o_procid,_w/o_structured_data,_with_message-10  14832892   397.8 ns/op   308 B/op   9 allocs/op
-[ok]_minimal_with_UTF-8_message___________________-10  20229313   306.2 ns/op   339 B/op   6 allocs/op
-[ok]_minimal_with_UTF-8_message_starting_with_BOM_-10  19721539   306.7 ns/op   355 B/op   6 allocs/op
-[ok]_with_structured_data_id,_w/o_structured_data_-10  13860580   435.7 ns/op   538 B/op  10 allocs/op
-[ok]_with_multiple_structured_data________________-10   8368731   721.9 ns/op  1173 B/op  15 allocs/op
-[ok]_with_escaped_backslash_within_structured_data-10   9730569   632.6 ns/op   864 B/op  16 allocs/op
-[ok]_with_UTF-8_structured_data_param_value,_with_-10   8864156   660.6 ns/op   858 B/op  15 allocs/op
+[no]_empty_input__________________________________-14  45358116   127.3 ns/op   272 B/op   4 allocs/op
+[no]_multiple_syslog_messages_on_multiple_lines___-14  38895066   154.8 ns/op   283 B/op   7 allocs/op
+[no]_impossible_timestamp_________________________-14  12993157   463.4 ns/op   571 B/op  12 allocs/op
+[no]_malformed_structured_data____________________-14  25974694   228.3 ns/op   515 B/op   8 allocs/op
+[no]_with_duplicated_structured_data_id___________-14  13554434   440.4 ns/op   688 B/op  15 allocs/op
+[ok]_minimal______________________________________-14  64324653   91.11 ns/op   243 B/op   5 allocs/op
+[ok]_average_message______________________________-14   8714227   704.8 ns/op  1360 B/op  20 allocs/op
+[ok]_complicated_message__________________________-14   8980812   625.4 ns/op  1248 B/op  23 allocs/op
+[ok]_very_long_message____________________________-14   3569872    1642 ns/op  2288 B/op  21 allocs/op
+[ok]_all_max_length_and_complete__________________-14   4835001    1261 ns/op  1864 B/op  27 allocs/op
+[ok]_all_max_length_except_structured_data_and_mes-14   7233706   816.2 ns/op   867 B/op  12 allocs/op
+[ok]_minimal_with_message_containing_newline______-14  58016277   103.0 ns/op   246 B/op   6 allocs/op
+[ok]_w/o_procid,_w/o_structured_data,_with_message-14  22200367   269.7 ns/op   324 B/op   9 allocs/op
+[ok]_minimal_with_UTF-8_message___________________-14  28426178   212.2 ns/op   355 B/op   6 allocs/op
+[ok]_minimal_with_UTF-8_message_starting_with_BOM_-14  27452876   220.4 ns/op   371 B/op   6 allocs/op
+[ok]_with_structured_data_id,_w/o_structured_data_-14  20122576   299.7 ns/op   554 B/op  10 allocs/op
+[ok]_with_multiple_structured_data________________-14  11264368   526.1 ns/op  1189 B/op  15 allocs/op
+[ok]_with_escaped_backslash_within_structured_data-14  13686079   443.7 ns/op   880 B/op  16 allocs/op
+[ok]_with_UTF-8_structured_data_param_value,_with_-14  13543791   439.2 ns/op   874 B/op  15 allocs/op
 ```
 
 Approximate parsing times:
 
-- 125 ns for the smallest legal message
-- less than 1 µs for an average legal message
-- 2 µs for a very long legal message
+- 91 ns for the smallest legal message
+- 705 ns for an average legal message
+- 1.64 µs for a very long legal message
 
 For comparison, this [Rust RFC 5424 implementation](https://github.com/roguelazer/rust-syslog-rfc5424)
 reports 8 µs for an average legal message.
-
----
-
-<a id="mymachine"></a>Test system: Apple M1 Pro

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)](LICENSE)
 
-**A parser for Syslog messages and transports**.
+**Parsers for syslog messages and transports**
 
-> [Blazing fast](#Performances) Syslog parsers
+> [Blazing fast](#performance) Syslog parsers
 
 _By [@leodido](https://github.com/leodido)_.
 
@@ -10,18 +10,18 @@ _This is the official continuation of influxdata/go-syslog_.
 
 This module includes:
 
-- an [RFC5424-compliant parser and builder](/rfc5424)
-- an [RFC3164-compliant parser](/rfc3164) - ie., BSD-syslog messages
-- an [auto-detect parser](/auto) that determines RFC 3164 vs RFC 5424 format per-message
-- an [RFC3195 parser](/rfc3195) for syslog over [BEEP](https://datatracker.ietf.org/doc/html/rfc3195) (RAW and COOKED profiles)
-- a parser that works on streams for syslog with [octet counting](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.1) framing technique, see [octetcounting](/octetcounting)
-- a parser that works on streams for syslog with [non-transparent](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.2) framing technique, see [nontransparent](/nontransparent)
+- an [RFC 5424-compliant parser and builder](/rfc5424)
+- an [RFC 3164-compliant parser](/rfc3164) for BSD syslog messages
+- an [auto-detect parser](/auto) that selects RFC 3164 or RFC 5424 per message
+- an [RFC 3195 parser](/rfc3195) for syslog over [BEEP](https://datatracker.ietf.org/doc/html/rfc3195), including RAW and COOKED profiles
+- an [octet-counting stream parser](/octetcounting) for [RFC 6587 transparent framing](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.1)
+- a [non-transparent stream parser](/nontransparent) for [RFC 6587 delimiter framing](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.2)
 
 It can parse syslog messages received over:
 
-- TLS with octet count ([RFC5425](https://datatracker.ietf.org/doc/html/rfc5425))
-- TCP with non-transparent framing or with octet count ([RFC 6587](https://datatracker.ietf.org/doc/html/rfc6587))
-- UDP carrying one message per packet ([RFC5426](https://datatracker.ietf.org/doc/html/rfc5426))
+- TLS with octet counting ([RFC 5425](https://datatracker.ietf.org/doc/html/rfc5425))
+- TCP with non-transparent framing or octet counting ([RFC 6587](https://datatracker.ietf.org/doc/html/rfc6587))
+- UDP carrying one message per packet ([RFC 5426](https://datatracker.ietf.org/doc/html/rfc5426))
 
 ## Installation
 
@@ -41,7 +41,7 @@ The [docs](docs/) directory contains `.dot` files representing the finite-state 
 
 [![Build with Ona](https://ona.com/build-with-ona.svg)](https://app.ona.com/#https://github.com/leodido/go-syslog)
 
-Parse RFC5424 messages with `rfc5424.NewParser`. The RFC3164 parser uses the
+Parse RFC 5424 messages with `rfc5424.NewParser`. The RFC 3164 parser uses the
 same interface; its options are demonstrated in
 [rfc3164/example_test.go](./rfc3164/example_test.go).
 
@@ -75,7 +75,7 @@ This results in `m` being equal to:
 // })
 ```
 
-`e` is nil because the input is a valid RFC5424 message.
+`e` is nil because the input is a valid RFC 5424 message.
 
 ### Messages without PRI
 
@@ -89,7 +89,7 @@ rfc5424Parser := rfc5424.NewParser(rfc5424.WithOptionalPriority())
 
 When PRI is absent, `Priority`, `Facility`, and `Severity` are nil. Options can
 be combined; for example, VMware ESXi messages commonly need both optional PRI
-and fractional RFC3339 timestamps:
+and fractional RFC 3339 timestamps:
 
 ```go
 esxiParser := rfc3164.NewParser(
@@ -101,7 +101,7 @@ esxiParser := rfc3164.NewParser(
 ### Best effort mode
 
 With `WithBestEffort()`, a parse error returns the fields collected before the
-failure. An RFC5424 partial result requires PRI and VERSION, or VERSION alone
+failure. An RFC 5424 partial result requires PRI and VERSION, or VERSION alone
 when `WithOptionalPriority()` is also set.
 
 ```go
@@ -133,17 +133,17 @@ m, e := p.Parse(i)
 ```
 
 Both `m` and `e` are non-nil because the parser collected a valid partial
-RFC5424 message before the error.
+RFC 5424 message before the error.
 
 ### Builder
 
-Use `SyslogMessage` to construct RFC5424 messages. `Valid()` checks parser-level
+Use `SyslogMessage` to construct RFC 5424 messages. `Valid()` checks parser-level
 structure; `String()` requires PRI. Setters ignore values that do not match the
 grammar.
 
 ```go
 msg := &rfc5424.SyslogMessage{}
-msg.SetTimestamp("not a RFC3339MICRO timestamp")
+msg.SetTimestamp("invalid timestamp")
 msg.Valid() // Not yet a valid message (try msg.Valid())
 msg.SetPriority(191)
 msg.SetVersion(1)
@@ -177,7 +177,7 @@ str, _ := msg.String()
 
 ### Auto-detect
 
-Use the [auto](/auto) package when a source mixes RFC5424 and RFC3164 messages.
+Use the [auto](/auto) package when a source mixes RFC 5424 and RFC 3164 messages.
 
 ```go
 m := auto.NewMachine()
@@ -208,28 +208,25 @@ The stream packages also expose `NewParserAuto` - see
 below. Their auto-detect parsers currently require each syslog payload to begin
 with PRI. Priorityless auto-detection is available only through `auto.Machine`.
 
-For messages without PRI, auto-detection recognizes RFC3164 timestamps that
+For messages without PRI, auto-detection recognizes RFC 3164 timestamps that
 start with a three-letter month or a four-digit year followed by `-`. Other
-priorityless inputs are tried as RFC5424 first. Unless `WithoutFallback()` is
+priorityless inputs are tried as RFC 5424 first. Unless `WithoutFallback()` is
 set, a complete parse failure causes the other parser to be tried.
 
 ## Message transfer
 
-Excluding encapsulating one message for packet in packet protocols there are two ways to transfer syslog messages over streams.
-
-The older - ie., the **non-transparent** framing - and the newer one - ie., the **octet counting** framing - which is reliable and has not been seen to cause problems noted with the non-transparent one.
-
-This library provide stream parsers for both.
+Packet-oriented transports carry one syslog message per packet. Stream
+transports use non-transparent or octet-counting framing. This library provides
+parsers for both stream formats.
 
 ### Octet counting
 
-In short, [RFC5425](https://datatracker.ietf.org/doc/html/rfc5425#section-4.3) and [RFC6587](https://datatracker.ietf.org/doc/html/rfc6587), aside from the protocol considerations, describe a **transparent framing** technique for Syslog messages that uses the **octect counting** technique - ie., the message length of the incoming message.
+[RFC 5425](https://datatracker.ietf.org/doc/html/rfc5425#section-4.3) and
+[RFC 6587](https://datatracker.ietf.org/doc/html/rfc6587) describe transparent
+framing with octet counting. Each message is prefixed with its byte length.
 
-Each Syslog message is sent with a prefix representing the number of bytes it is made of.
-
-The [octecounting package](./octetcounting) parses messages stream following such rule.
-
-To quickly understand how to use it please have a look at the [example file](./octetcounting/example_test.go).
+The [octetcounting package](./octetcounting) parses this framing. See its
+[examples](./octetcounting/example_test.go).
 
 If you have mixed RFC 5424 and RFC 3164 messages in the same stream, use `NewParserAuto`:
 
@@ -243,17 +240,14 @@ p := octetcounting.NewParserAuto(
 p.Parse(reader)
 ```
 
-### Non transparent
+### Non-transparent framing
 
-The [RFC6587](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.2) also describes the **non-transparent framing** transport of syslog messages.
+[RFC 6587](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.2)
+also defines non-transparent framing, in which a delimiter—usually a line
+feed—separates messages. The [nontransparent package](./nontransparent) parses
+this framing. See its [examples](./nontransparent/example_test.go).
 
-In such case the messages are separated by a trailer, usually a line feed.
-
-The [nontransparent package](./nontransparent) parses message stream following such [technique](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.2).
-
-To quickly understand how to use it please have a look at the [example file](./nontransparent/example_test.go).
-
-Same as octet counting, use `NewParserAuto` for mixed-format streams:
+As with octet counting, use `NewParserAuto` for mixed-format streams:
 
 ```go
 p := nontransparent.NewParserAuto(
@@ -265,11 +259,11 @@ p := nontransparent.NewParserAuto(
 p.Parse(reader)
 ```
 
-Things we do not support:
+Unsupported delimiter configurations:
 
 - trailers other than `LF` or `NUL`
-- trailers which length is greater than 1 byte
-- trailer change on a frame-by-frame basis
+- trailers longer than one byte
+- changing the trailer between frames
 
 ### RFC 3195 (BEEP)
 
@@ -280,19 +274,21 @@ Things we do not support:
 
 The [rfc3195 package](./rfc3195) provides parsers for both profiles. It implements BEEP frame scanning (MSG, RPY, ERR, ANS, NUL, SEQ frames) and extracts syslog messages from the frame payloads.
 
-This is a parsing-only implementation - it does not handle BEEP session management, channel negotiation, or TLS. Feed it a stream of BEEP frames and it will emit parsed syslog messages.
+This parser does not handle BEEP session management, channel negotiation, or
+TLS. Feed it BEEP frames and it emits parsed syslog messages. See the
+[examples](./rfc3195/example_test.go).
 
-To quickly understand how to use it please have a look at the [example file](./rfc3195/example_test.go).
+## Performance
 
-## Performances
-
-To run the benchmark execute the following command.
+Run the benchmarks with:
 
 ```bash
 make bench
 ```
 
-On my machine<sup>[1](#mymachine)</sup> these are the results obtained paring RFC5424 syslog messages with best effort mode on.
+The following results were measured on
+[this machine](#mymachine) while parsing RFC 5424 messages with best-effort mode
+enabled.
 
 ```
 [no]_empty_input__________________________________-10  32072733   185.3 ns/op   272 B/op   4 allocs/op
@@ -316,16 +312,15 @@ On my machine<sup>[1](#mymachine)</sup> these are the results obtained paring RF
 [ok]_with_UTF-8_structured_data_param_value,_with_-10   8864156   660.6 ns/op   858 B/op  15 allocs/op
 ```
 
-As you can see it takes:
+Approximate parsing times:
 
-* ~125ns to parse the smallest legal message
+- 125 ns for the smallest legal message
+- less than 1 µs for an average legal message
+- 2 µs for a very long legal message
 
-* less than 1µs to parse an average legal message
-
-* ~2µs to parse a very long legal message
-
-Other RFC5424 implementations, like this [one](https://github.com/roguelazer/rust-syslog-rfc5424) in Rust, spend 8µs to parse an average legal message.
+For comparison, this [Rust RFC 5424 implementation](https://github.com/roguelazer/rust-syslog-rfc5424)
+reports 8 µs for an average legal message.
 
 ---
 
-* <a name="mymachine">[1]</a>: Apple M1 Pro
+<a id="mymachine"></a>Test system: Apple M1 Pro

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ This module includes:
 - an [auto-detect parser](/auto) that determines RFC 3164 vs RFC 5424 format per-message
 - an [RFC3195 parser](/rfc3195) for syslog over [BEEP](https://datatracker.ietf.org/doc/html/rfc3195) (RAW and COOKED profiles)
 - a parser that works on streams for syslog with [octet counting](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.1) framing technique, see [octetcounting](/octetcounting)
-- a parser that works on streams for syslog with [non-transparent](https://tools.ietf.org/html/rfc6587#section-3.4.2) framing technique, see [nontransparent](/nontransparent)
+- a parser that works on streams for syslog with [non-transparent](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.2) framing technique, see [nontransparent](/nontransparent)
 
 It can parse syslog messages received over:
 
-- TLS with octet count ([RFC5425](https://tools.ietf.org/html/rfc5425))
-- TCP with non-transparent framing or with octet count ([RFC 6587](https://tools.ietf.org/html/rfc6587))
-- UDP carrying one message per packet ([RFC5426](https://tools.ietf.org/html/rfc5426))
+- TLS with octet count ([RFC5425](https://datatracker.ietf.org/doc/html/rfc5425))
+- TCP with non-transparent framing or with octet count ([RFC 6587](https://datatracker.ietf.org/doc/html/rfc6587))
+- UDP carrying one message per packet ([RFC5426](https://datatracker.ietf.org/doc/html/rfc5426))
 
 ## Installation
 
@@ -223,7 +223,7 @@ This library provide stream parsers for both.
 
 ### Octet counting
 
-In short, [RFC5425](https://tools.ietf.org/html/rfc5425#section-4.3) and [RFC6587](https://tools.ietf.org/html/rfc6587), aside from the protocol considerations, describe a **transparent framing** technique for Syslog messages that uses the **octect counting** technique - ie., the message length of the incoming message.
+In short, [RFC5425](https://datatracker.ietf.org/doc/html/rfc5425#section-4.3) and [RFC6587](https://datatracker.ietf.org/doc/html/rfc6587), aside from the protocol considerations, describe a **transparent framing** technique for Syslog messages that uses the **octect counting** technique - ie., the message length of the incoming message.
 
 Each Syslog message is sent with a prefix representing the number of bytes it is made of.
 
@@ -245,11 +245,11 @@ p.Parse(reader)
 
 ### Non transparent
 
-The [RFC6587](https://tools.ietf.org/html/rfc6587#section-3.4.2) also describes the **non-transparent framing** transport of syslog messages.
+The [RFC6587](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.2) also describes the **non-transparent framing** transport of syslog messages.
 
 In such case the messages are separated by a trailer, usually a line feed.
 
-The [nontransparent package](./nontransparent) parses message stream following such [technique](https://tools.ietf.org/html/rfc6587#section-3.4.2).
+The [nontransparent package](./nontransparent) parses message stream following such [technique](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.2).
 
 To quickly understand how to use it please have a look at the [example file](./nontransparent/example_test.go).
 

--- a/README.md
+++ b/README.md
@@ -203,11 +203,10 @@ m := auto.NewMachine(
 )
 ```
 
-`NewParserAuto` also provides auto-detection to the stream parsers for
-PRI-bearing messages - see [octet counting](#octet-counting) and
-[non-transparent](#non-transparent) below. Stream framing still requires the
-syslog payload to begin with PRI, so priorityless auto-detection currently
-applies only when parsing directly with `auto.Machine`.
+The stream packages also expose `NewParserAuto` - see
+[octet counting](#octet-counting) and [non-transparent](#non-transparent)
+below. Their auto-detect parsers currently require each syslog payload to begin
+with PRI. Priorityless auto-detection is available only through `auto.Machine`.
 
 Auto-detect chooses a format before parsing. Inputs beginning with `<` scan for
 the first `>` and then use the existing post-PRI VERSION-versus-timestamp

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _By [@leodido](https://github.com/leodido)_.
 
 _This is the official continuation of influxdata/go-syslog_.
 
-To wrap up, this package provides:
+This module includes:
 
 - an [RFC5424-compliant parser and builder](/rfc5424)
 - an [RFC3164-compliant parser](/rfc3164) - ie., BSD-syslog messages
@@ -17,9 +17,7 @@ To wrap up, this package provides:
 - a parser that works on streams for syslog with [octet counting](https://datatracker.ietf.org/doc/html/rfc6587#section-3.4.1) framing technique, see [octetcounting](/octetcounting)
 - a parser that works on streams for syslog with [non-transparent](https://tools.ietf.org/html/rfc6587#section-3.4.2) framing technique, see [nontransparent](/nontransparent)
 
-This library provides the pieces to parse Syslog messages transported following various RFCs.
-
-For example:
+It can parse syslog messages received over:
 
 - TLS with octet count ([RFC5425](https://tools.ietf.org/html/rfc5425))
 - TCP with non-transparent framing or with octet count ([RFC 6587](https://tools.ietf.org/html/rfc6587))
@@ -43,9 +41,9 @@ The [docs](docs/) directory contains `.dot` files representing the finite-state 
 
 [![Build with Ona](https://ona.com/build-with-ona.svg)](https://app.ona.com/#https://github.com/leodido/go-syslog)
 
-Suppose you want to parse a given sequence of bytes as a RFC5424 message.
-
-_Notice that the same interface applies for RFC3164. But you can always take a look at the [examples file](./rfc3164/example_test.go)._
+Parse RFC5424 messages with `rfc5424.NewParser`. The RFC3164 parser uses the
+same interface; its options are demonstrated in
+[rfc3164/example_test.go](./rfc3164/example_test.go).
 
 ```go
 i := []byte(`<165>4 2018-10-11T22:14:15.003Z mymach.it e - 1 [ex@32473 iut="3"] An application event log entry...`)
@@ -77,7 +75,7 @@ This results in `m` being equal to:
 // })
 ```
 
-And `e` being equal to `nil` since the `i` byte slice contains a perfectly valid RFC5424 message.
+`e` is nil because the input is a valid RFC5424 message.
 
 ### Messages without PRI
 
@@ -102,23 +100,15 @@ esxiParser := rfc3164.NewParser(
 
 ### Best effort mode
 
-RFC5424 parser has the ability to perform partial matches (until it can).
-
-With this mode enabled, when the parsing process errors out it returns the message collected until that position, and the error that caused the parser to stop.
-
-By default, best-effort parsing returns a partial RFC5424 message only after a
-valid PRI and VERSION have been parsed. With `WithOptionalPriority()`, PRI may
-be absent and a valid VERSION is the parser-level minimum.
-
-Let's look at an example.
+With `WithBestEffort()`, a parse error returns the fields collected before the
+failure. An RFC5424 partial result requires PRI and VERSION, or VERSION alone
+when `WithOptionalPriority()` is also set.
 
 ```go
 i := []byte("<1>1 A - - - - - -")
 p := rfc5424.NewParser(rfc5424.WithBestEffort())
 m, e := p.Parse(i)
 ```
-
-This results in `m` being equal to the following `SyslogMessage` instance.
 
 ```go
 // (*rfc5424.SyslogMessage)({
@@ -138,26 +128,18 @@ This results in `m` being equal to the following `SyslogMessage` instance.
 // })
 ```
 
-And, at the same time, in `e` reporting the error that actually stopped the parser.
-
 ```go
 // expecting a RFC3339MICRO timestamp or a nil value [col 5]
 ```
 
-Both `m` and `e` have a value since at the column the parser stopped it already was able to construct a minimally valid RFC5424 `SyslogMessage`.
+Both `m` and `e` are non-nil because the parser collected a valid partial
+RFC5424 message before the error.
 
 ### Builder
 
-This library also provides a builder to construct valid syslog messages.
-
-`SyslogMessage.Valid()` reports parser-level structural validity. A message
-with a valid VERSION and no PRI can therefore be valid after priorityless
-parsing, but `String()` deliberately remains stricter and returns an error
-unless PRI is present.
-
-Notice that its API ignores input values that does not match the grammar.
-
-Let's have a look to an example.
+Use `SyslogMessage` to construct RFC5424 messages. `Valid()` checks parser-level
+structure; `String()` requires PRI. Setters ignore values that do not match the
+grammar.
 
 ```go
 msg := &rfc5424.SyslogMessage{}
@@ -168,7 +150,7 @@ msg.SetVersion(1)
 msg.Valid() // Now it is minimally valid
 ```
 
-Printing `msg` you will verify it contains a `nil` timestamp (since an invalid one has been given).
+The invalid timestamp is ignored, so `Timestamp` remains nil.
 
 ```go
 // (*rfc5424.SyslogMessage)({
@@ -188,8 +170,6 @@ Printing `msg` you will verify it contains a `nil` timestamp (since an invalid o
 // })
 ```
 
-Finally you can serialize the message into a string.
-
 ```go
 str, _ := msg.String()
 // <191>1 - - - - - -
@@ -197,7 +177,7 @@ str, _ := msg.String()
 
 ### Auto-detect
 
-Suppose you don't know whether incoming messages are RFC 5424 or RFC 3164. The [auto](/auto) package figures it out per-message.
+Use the [auto](/auto) package when a source mixes RFC5424 and RFC3164 messages.
 
 ```go
 m := auto.NewMachine()
@@ -205,7 +185,7 @@ msg, err := m.Parse(input)
 fmt.Println(auto.DetectFormat(msg)) // "rfc5424" or "rfc3164"
 ```
 
-You can pass format-specific options to each inner parser:
+Pass format-specific options to each inner parser:
 
 ```go
 m := auto.NewMachine(
@@ -214,8 +194,7 @@ m := auto.NewMachine(
 )
 ```
 
-To accept messages that omit PRI, enable the parser option for both inner
-formats. Strict PRI handling remains the default when these options are absent.
+Priorityless auto-detection requires the option on both inner parsers:
 
 ```go
 m := auto.NewMachine(

--- a/README.md
+++ b/README.md
@@ -229,11 +229,10 @@ The stream packages also expose `NewParserAuto` - see
 below. Their auto-detect parsers currently require each syslog payload to begin
 with PRI. Priorityless auto-detection is available only through `auto.Machine`.
 
-Auto-detect chooses a format before parsing. Inputs beginning with `<` scan for
-the first `>` and then use the existing post-PRI VERSION-versus-timestamp
-heuristic. Inputs without PRI use narrow leading signatures: an RFC3164 month
-or four-digit RFC3339 year selects RFC3164, while other inputs default to
-RFC5424.
+For messages without PRI, auto-detection recognizes RFC3164 timestamps that
+start with a three-letter month or a four-digit year followed by `-`. Other
+priorityless inputs are tried as RFC5424 first. Unless `WithoutFallback()` is
+set, a complete parse failure causes the other parser to be tried.
 
 ## Message transfer
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ This results in `m` being equal to:
 
 And `e` being equal to `nil` since the `i` byte slice contains a perfectly valid RFC5424 message.
 
+### Messages without PRI
+
+Both parsers require PRI by default. Use `WithOptionalPriority()` to accept an
+otherwise valid message without it:
+
+```go
+rfc3164Parser := rfc3164.NewParser(rfc3164.WithOptionalPriority())
+rfc5424Parser := rfc5424.NewParser(rfc5424.WithOptionalPriority())
+```
+
+When PRI is absent, `Priority`, `Facility`, and `Severity` are nil. Options can
+be combined; for example, VMware ESXi messages commonly need both optional PRI
+and fractional RFC3339 timestamps:
+
+```go
+esxiParser := rfc3164.NewParser(
+    rfc3164.WithOptionalPriority(),
+    rfc3164.WithRFC3339(),
+)
+```
+
 ### Best effort mode
 
 RFC5424 parser has the ability to perform partial matches (until it can).

--- a/rfc3164/README.md
+++ b/rfc3164/README.md
@@ -1,6 +1,6 @@
 # RFC 3164 Syslog Parser
 
-This package parses RFC3164 (BSD syslog) messages. It accepts the standard
+This package parses RFC 3164 (BSD syslog) messages. It accepts the standard
 format by default and provides the opt-in extensions listed below.
 
 ## Message Format
@@ -46,9 +46,9 @@ When PRI is absent, `Priority`, `Facility`, and `Severity` are nil. A fully
 parsed priorityless message is still valid: `SyslogMessage.Valid()` requires
 its timestamp and message fields when no priority is present.
 
-### RFC3339 Timestamps
+### RFC 3339 Timestamps
 
-`WithRFC3339()` accepts RFC3339 timestamps in RFC3164-style messages:
+`WithRFC3339()` accepts RFC 3339 timestamps in RFC 3164-style messages:
 
 ```go
 p := rfc3164.NewParser(rfc3164.WithRFC3339())
@@ -59,7 +59,8 @@ Stamp timestamps remain accepted.
 
 ### Timezone Configuration
 
-By default, timestamps without timezone information use UTC. You can specify a different timezone:
+Timestamps without timezone information use UTC by default. To use another
+timezone:
 
 ```go
 loc, _ := time.LoadLocation("America/New_York")
@@ -70,7 +71,7 @@ p := rfc3164.NewParser(
 
 ### Year Specification
 
-RFC3164 timestamps don't include the year. Specify it explicitly:
+RFC 3164 timestamps do not include the year. Specify it explicitly:
 
 ```go
 p := rfc3164.NewParser(
@@ -172,7 +173,7 @@ ntp server <your-ntp-server>
 
 ### Format Ambiguities
 
-RFC3164 leaves several fields underspecified:
+RFC 3164 leaves several fields underspecified:
 
 - No standard field delimiters beyond whitespace
 - Hostname and tag can be ambiguous
@@ -185,14 +186,14 @@ Unsupported formats tracked in
 [issue #61](https://github.com/leodido/go-syslog/issues/61) include:
 
 - BSD-style timestamps that contain a year
-- Unix-epoch timestamps, including fractional epochs
+- Unix epoch timestamps, including fractional epochs
 - named timezone tokens embedded after a timestamp, such as `IST` or `SST`
 - counter, hostname, or task fields outside the supported Cisco IOS ordering
-- RFC5424-like envelopes that use an `app[pid]:` tag instead of separate fields
+- RFC 5424-like envelopes that use an `app[pid]:` tag instead of separate fields
 
 ### Cisco IOS Limitations
 
 - Component ordering must match the parser options. A mismatch can fail parsing
   or assign fields incorrectly.
-- RFC5424-style structured data from `logging host X session-id` or
+- RFC 5424-style structured data from `logging host X session-id` or
   `sequence-num-session` is not supported. See issue #35.

--- a/rfc3164/README.md
+++ b/rfc3164/README.md
@@ -1,50 +1,42 @@
 # RFC 3164 Syslog Parser
 
-This package implements a parser for RFC3164 (BSD syslog) messages with extensions for common non-standard formats.
+This package parses RFC3164 (BSD syslog) messages. It accepts the standard
+format by default and provides the opt-in extensions listed below.
 
-## Overview
-
-RFC3164 is the original syslog protocol specification, commonly known as BSD syslog. Unlike [RFC5424](../rfc5424), RFC3164 has a loosely defined format, making it challenging to parse reliably. This parser handles the standard format plus common variations.
-
-## Standard RFC3164 Format
+## Message Format
 
 ```
 <PRI>TIMESTAMP HOSTNAME TAG[PROCID]: MESSAGE
 ```
 
-Example:
-
 ```
 <34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8
 ```
 
-## Basic Usage
+## Usage
 
 ```go
 import "github.com/leodido/go-syslog/v4/rfc3164"
 
-// Create a parser
 p := rfc3164.NewParser()
 
-// Parse a message
 msg, err := p.Parse([]byte("<34>Oct 11 22:14:15 mymachine su: 'su root' failed"))
 if err != nil {
     log.Fatal(err)
 }
 
-// Access parsed fields
 m := msg.(*rfc3164.SyslogMessage)
 fmt.Printf("Priority: %d\n", *m.Priority)
 fmt.Printf("Hostname: %s\n", *m.Hostname)
 fmt.Printf("Message: %s\n", *m.Message)
 ```
 
-## Parser Options
+## Options
 
 ### Optional Priority
 
-PRI remains required by default. For senders that omit PRI but otherwise emit
-RFC3164 messages, enable `WithOptionalPriority()`:
+PRI is required by default. `WithOptionalPriority()` accepts an otherwise valid
+message without it:
 
 ```go
 p := rfc3164.NewParser(rfc3164.WithOptionalPriority())
@@ -56,8 +48,7 @@ its timestamp and message fields when no priority is present.
 
 ### RFC3339 Timestamps
 
-Enable `WithRFC3339()` for senders that place an RFC3339 timestamp in an
-RFC3164-style message:
+`WithRFC3339()` accepts RFC3339 timestamps in RFC3164-style messages:
 
 ```go
 p := rfc3164.NewParser(rfc3164.WithRFC3339())
@@ -97,9 +88,9 @@ p := rfc3164.NewParser(
 )
 ```
 
-### Cisco IOS Support
+### Cisco IOS
 
-Cisco IOS devices send non-standard syslog messages with additional fields before the timestamp. This parser supports these extensions.
+Cisco IOS can add fields before the timestamp. Their order is configurable.
 
 ```
 <PRI>[msgcount:] [sequence:] [hostname:] [*]TIMESTAMP: MESSAGE
@@ -111,7 +102,7 @@ Example:
 <189>237: 000485: router1: *Jan 8 19:46:03.295: %LINEPROTO-5-UPDOWN: Line protocol on Interface Loopback100, changed state to up
 ```
 
-#### Enabling Cisco Support
+#### Configuration
 
 ```go
 import (
@@ -134,8 +125,6 @@ p := rfc3164.NewParser(
 
 #### Cisco Components
 
-For Cisco IOS configuration details, see the `WithCiscoIOSComponents()` function documentation.
-
 | Component        | Description             | Cisco Command                                                        |
 | ---------------- | ----------------------- | -------------------------------------------------------------------- |
 | Message Counter  | Remote logging counter  | Enabled by default; disable with `no logging message-counter syslog` |
@@ -144,11 +133,10 @@ For Cisco IOS configuration details, see the `WithCiscoIOSComponents()` function
 | Milliseconds     | Timestamp precision     | `service timestamps log datetime msec`                               |
 | Asterisk         | NTP sync indicator      | Appears when NTP not synchronized                                    |
 
-#### Configuration Matching Requirement
+#### Matching Device Configuration
 
-**Important**: Your parser configuration must match your Cisco device configuration. The parser cannot auto-detect which components are present because they share similar formats (mostly digits followed by colon).
-
-What happens when there's a mismatch?
+Parser options must match the fields emitted by the device. Numeric components
+cannot be distinguished reliably from their values alone.
 
 ```go
 // Device sends both message counter and sequence number: <189>237: 000485: *Jan 8 19:46:03.295: ...
@@ -160,7 +148,7 @@ p := rfc3164.NewParser(
 // Parser found digits where it expects timestamp, indicating sequence parsing should be enabled.
 ```
 
-##### Cisco Device Configuration
+##### Example Device Configuration
 
 ```cisco
 conf t
@@ -182,9 +170,9 @@ ntp server <your-ntp-server>
 
 ## Known Limitations
 
-### Ambiguities
+### Format Ambiguities
 
-RFC3164 has an underspecified format, leading to parsing challenges:
+RFC3164 leaves several fields underspecified:
 
 - No standard field delimiters beyond whitespace
 - Hostname and tag can be ambiguous
@@ -193,9 +181,8 @@ RFC3164 has an underspecified format, leading to parsing challenges:
 
 ### Other Vendor Formats
 
-The opt-in extensions above do not cover every device syntax. The remaining
-formats tracked in [issue #61](https://github.com/leodido/go-syslog/issues/61)
-include:
+Unsupported formats tracked in
+[issue #61](https://github.com/leodido/go-syslog/issues/61) include:
 
 - BSD-style timestamps that contain a year
 - Unix-epoch timestamps, including fractional epochs
@@ -205,6 +192,7 @@ include:
 
 ### Cisco IOS Limitations
 
-**Component Ordering**: When Cisco components are selectively disabled on the device but the parser expects them, parsing will fail or produce incorrect results. Always match your parser configuration to your device configuration.
-
-**Structured Data**: Cisco IOS messages with RFC5424-style structured data blocks (from `logging host X session-id` or `sequence-num-session`) are not currently supported. See issue #35 for details.
+- Component ordering must match the parser options. A mismatch can fail parsing
+  or assign fields incorrectly.
+- RFC5424-style structured data from `logging host X session-id` or
+  `sequence-num-session` is not supported. See issue #35.

--- a/rfc3164/README.md
+++ b/rfc3164/README.md
@@ -191,6 +191,18 @@ RFC3164 has an underspecified format, leading to parsing challenges:
 - No year in timestamps
 - No timezone specification in basic format
 
+### Other Vendor Formats
+
+The opt-in extensions above do not cover every device syntax. The remaining
+formats tracked in [issue #61](https://github.com/leodido/go-syslog/issues/61)
+include:
+
+- BSD-style timestamps that contain a year
+- Unix-epoch timestamps, including fractional epochs
+- named timezone tokens embedded after a timestamp, such as `IST` or `SST`
+- counter, hostname, or task fields outside the supported Cisco IOS ordering
+- RFC5424-like envelopes that use an `app[pid]:` tag instead of separate fields
+
 ### Cisco IOS Limitations
 
 **Component Ordering**: When Cisco components are selectively disabled on the device but the parser expects them, parsing will fail or produce incorrect results. Always match your parser configuration to your device configuration.

--- a/rfc3164/example_test.go
+++ b/rfc3164/example_test.go
@@ -59,6 +59,44 @@ func Example_readme() {
 	// Message: 'su root' failed
 }
 
+func Example_optionalPriority() {
+	p := NewParser(WithOptionalPriority())
+	msg, err := p.Parse([]byte("Oct 11 22:14:15 mymachine su: message"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	m := msg.(*SyslogMessage)
+	fmt.Println("Priority absent:", m.Priority == nil)
+	fmt.Println("Hostname:", *m.Hostname)
+	fmt.Println("Message:", *m.Message)
+
+	// Output:
+	// Priority absent: true
+	// Hostname: mymachine
+	// Message: message
+}
+
+func Example_optionalPriorityRFC3339() {
+	p := NewParser(WithOptionalPriority(), WithRFC3339())
+	msg, err := p.Parse([]byte("2024-07-25T18:54:02.265Z esxi-a vmkernel: Event message"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	m := msg.(*SyslogMessage)
+	fmt.Println("Priority absent:", m.Priority == nil)
+	fmt.Println("Timestamp:", m.Timestamp.Format(time.RFC3339Nano))
+	fmt.Println("Hostname:", *m.Hostname)
+	fmt.Println("App name:", *m.Appname)
+
+	// Output:
+	// Priority absent: true
+	// Timestamp: 2024-07-25T18:54:02.265Z
+	// Hostname: esxi-a
+	// App name: vmkernel
+}
+
 func Example_currentyear() {
 	i := []byte(`<13>Dec  2 16:31:03 host app: Test`)
 	p := NewParser(WithYear(CurrentYear{}))

--- a/rfc3164/machine.go.rl
+++ b/rfc3164/machine.go.rl
@@ -188,7 +188,7 @@ ciscoextras = msgcount? <: sequence? <: ciscoHostname?;
 
 # Section 4.1.3
 # note > alnum{1,32} is too restrictive (eg., no dashes)
-# note > see https://tools.ietf.org/html/rfc2234#section-2.1 for an interpretation of "ABNF alphanumeric" as stated by RFC 3164 regarding the tag
+# note > see https://datatracker.ietf.org/doc/html/rfc2234#section-2.1 for an interpretation of "ABNF alphanumeric" as stated by RFC 3164 regarding the tag
 # note > while RFC3164 assumes only ABNF alphanumeric process names, many BSD-syslog contains processe names with additional characters (-, _, .)
 # note > should be {1,32} but Unifi thinks it can be up to 48 characters
 tag = (print -- [ :\[]){1,48} >mark %set_tag @err(err_tag);

--- a/rfc3164/syslog_message.go
+++ b/rfc3164/syslog_message.go
@@ -55,7 +55,7 @@ func (sm *syslogMessage) export() *SyslogMessage {
 	}
 	if sm.content != "-" && sm.content != "" {
 		// Content is usually process ID
-		// See https://tools.ietf.org/html/rfc3164#section-5.3
+		// See https://datatracker.ietf.org/doc/html/rfc3164#section-5.3
 		out.ProcID = &sm.content
 	}
 	if sm.message != "" {

--- a/rfc5424/example_test.go
+++ b/rfc5424/example_test.go
@@ -52,6 +52,27 @@ func Example() {
 	// }
 }
 
+func Example_optionalPriority() {
+	p := NewParser(WithOptionalPriority())
+	msg, err := p.Parse([]byte("1 2023-04-05T16:20:56Z loki.example.com su - ID47 - some message"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	m := msg.(*SyslogMessage)
+	fmt.Println("Priority absent:", m.Priority == nil)
+	fmt.Println("Version:", m.Version)
+	fmt.Println("Hostname:", *m.Hostname)
+	fmt.Println("Message:", *m.Message)
+
+	// Output:
+	// Priority absent: true
+	// Version: 1
+	// Hostname: loki.example.com
+	// Message: some message
+}
+
 func Example_besteffort() {
 	i := []byte(`<1>1 A - - - - - -`)
 	p := NewParser(WithBestEffort())

--- a/rfc5424/options.go
+++ b/rfc5424/options.go
@@ -19,8 +19,8 @@ func WithBestEffort() syslog.MachineOption {
 // or
 // - a free-form message (0-255) not starting with a BOM marker.
 //
-// Ref.: https://tools.ietf.org/html/rfc5424#section-6.4
-// Ref.: https://tools.ietf.org/html/rfc5424#section-6
+// Ref.: https://datatracker.ietf.org/doc/html/rfc5424#section-6.4
+// Ref.: https://datatracker.ietf.org/doc/html/rfc5424#section-6
 func WithCompliantMsg() syslog.MachineOption {
 	return func(m syslog.Machine) syslog.Machine {
 		m.(*machine).compliantMsg = true


### PR DESCRIPTION
## Summary

- clarify optional-PRI behavior for direct, auto-detect, and stream parsers
- show the option combination used for priorityless VMware ESXi messages
- document the vendor formats that remain tracked by #61
- add executable RFC3164 and RFC5424 priorityless parsing examples
- replace detector implementation details with user-facing behavior
- tighten generated-sounding prose and replace large object dumps with focused examples
- preserve the existing README badges and Blazing fast wording while updating destinations and prose
- update pkg.go.dev and IETF references
- fix README grammar, spelling, terminology, and headings
- correct repository package links found by the GitHub-rendered link audit
- refresh the RFC5424 benchmark table with a full make bench run on Apple M4 Pro

## Commit structure

The original documentation cleanup remains split into ten focused commits, one for each accepted improvement. Two follow-up commits contain the link-audit fixes and benchmark refresh.

## Validation

- go test ./...
- go test ./... -run ^Example -count=1: all 35 examples pass
- make bench: full suite with five-second benchmark time
- git diff --check v4.6.0..HEAD
- all 20 external links return HTTP 200
- GitHub-rendered repository links, local paths, and anchors resolve correctly
- Markdown fences are balanced
