### PR TITLE
docs: remove stale Rust benchmark comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,3 @@ Approximate parsing times:
 - 91 ns for the smallest legal message
 - 705 ns for an average legal message
 - 1.64 µs for a very long legal message
-
-For comparison, this [Rust RFC 5424 implementation](https://github.com/roguelazer/rust-syslog-rfc5424)
-reports 8 µs for an average legal message.


### PR DESCRIPTION
## Summary

- remove the stale cross-project Rust benchmark comparison
- keep the freshly measured go-syslog benchmark table and summary unchanged
- avoid implying feature parity or drawing conclusions from different benchmark harnesses and feature sets

## Validation

- go test ./...
- git diff --check origin/develop..HEAD
- Markdown fences are balanced
- the PR contains one amended commit and removes only three README lines
